### PR TITLE
CUMULUS-1084

### DIFF
--- a/examples/contexts/lambda-context.json
+++ b/examples/contexts/lambda-context.json
@@ -1,5 +1,5 @@
 {
-    "function_name": "fakeStep",
-    "function_version": 1,
-    "invoked_function_arn": "arn:aws:lambda:us-east-1:123:function:fakeStep:1"
+    "functionName": "fakeStep",
+    "functionVersion": 1,
+    "invokedFunctionArn": "arn:aws:lambda:us-east-1:123:function:fakeStep:1"
 }

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -163,10 +163,13 @@ class message_adapter:
         * @returns {*} The task's configuration
         """
         meta = event['cumulus_meta']
-        if 'invokedFunctionArn' in context:
-            arn = context['invokedFunctionArn']
+        if isinstance(context, dict):
+            if 'invokedFunctionArn' in context:
+                arn = context['invokedFunctionArn']
+            else:
+                arn = context.get('invoked_function_arn', context.get('activityArn'))
         else:
-            arn = context.get('invoked_function_arn', context.get('activityArn'))
+            arn = context.invoked_function_arn
         taskName = self.__getCurrentSfnTask(meta['state_machine'], meta['execution_name'], arn)
         return self.__getConfig(event, taskName) if taskName is not None else None
 

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -120,9 +120,14 @@ class message_adapter:
         if context and 'meta' in event and 'workflow_tasks' in event['meta']:
             cumulus_meta = event['cumulus_meta']
             taskMeta = {}
-            taskMeta['name'] = context.get('function_name', context.get('functionName'))
-            taskMeta['version'] = context.get('function_version', context.get('functionVersion'))
-            taskMeta['arn'] = context.get('invoked_function_arn', context.get('invokedFunctionArn', context.get('activityArn')))
+            if isinstance(context, dict):
+                taskMeta['name'] = context.get('functionName')
+                taskMeta['version'] = context.get('functionVersion')
+                taskMeta['arn'] = context.get('invokedFunctionArn', context.get('activityArn'))
+            else:
+                taskMeta['name'] = context.function_name
+                taskMeta['version'] = context.function_version
+                taskMeta['arn'] = context.invoked_function_arn
             taskName = self.__getCurrentSfnTask(cumulus_meta['state_machine'], cumulus_meta['execution_name'], taskMeta['arn'])
             event['meta']['workflow_tasks'][taskName] = taskMeta
         return event

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -9,6 +9,15 @@ from jsonschema.exceptions import ValidationError
 
 from message_adapter import aws, message_adapter
 
+
+class TestPythonContext(object):
+    """ Test Context class to imitate the aws LambdaContext Object """
+    def __init__(self, context):
+        self.function_name = context.get('functionName')
+        self.function_version = context.get('functionVersion')
+        self.invoked_function_arn = context.get('invokedFunctionArn')
+
+
 class Test(unittest.TestCase):
     """ Test class """
 
@@ -24,7 +33,7 @@ class Test(unittest.TestCase):
     test_folder = os.path.join(os.getcwd(), 'examples/messages')
     context_folder = os.path.join(os.getcwd(), 'examples/contexts')
     schemas_folder = os.path.join(os.getcwd(), 'examples/schemas')
-    os.environ["LAMBDA_TASK_ROOT"] = os.path.join(os.getcwd(), 'examples')
+    os.environ['LAMBDA_TASK_ROOT'] = os.path.join(os.getcwd(), 'examples')
 
     def setUp(self):
         self.nested_response = {
@@ -280,14 +289,14 @@ class Test(unittest.TestCase):
         messageConfig = msg.get('messageConfig')
         if 'messageConfig' in msg: del msg['messageConfig']
         result = self.cumulus_message_adapter.createNextEvent(msg, remoteEvent, messageConfig)
-        
+
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(bucket_name).delete()
 
-        assert result == out_msg 
+        assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value='Example')
     def test_sfn(self, getCurrentSfnTask_function):
         """ test sfn.input.json """
         inp = open(os.path.join(self.test_folder, 'sfn.input.json'))
@@ -299,11 +308,28 @@ class Test(unittest.TestCase):
         messageConfig = msg.get('messageConfig')
         if 'messageConfig' in msg: del msg['messageConfig']
         result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
-        assert result == out_msg 
+        assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
-    def test_context(self, getCurrentSfnTask_function):
-        """ test storing context metadata """
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value='Example')
+    def test_python_context(self, getCurrentSfnTask_function):
+        """ test python storing context metadata """
+        inp = open(os.path.join(self.test_folder, 'context.input.json'))
+        out = open(os.path.join(self.test_folder, 'context.output.json'))
+        ctx = open(os.path.join(self.context_folder, 'lambda-context.json'))
+        in_msg = json.loads(inp.read())
+        out_msg = json.loads(out.read())
+        context = TestPythonContext(json.loads(ctx.read()))
+
+        rem = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, context)
+        msg = self.cumulus_message_adapter.loadNestedEvent(rem, context)
+        messageConfig = msg.get('messageConfig')
+        if 'messageConfig' in msg: del msg['messageConfig']
+        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        assert result == out_msg
+
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value='Example')
+    def test_js_context(self, getCurrentSfnTask_function):
+        """ test js storing context metadata """
         inp = open(os.path.join(self.test_folder, 'context.input.json'))
         out = open(os.path.join(self.test_folder, 'context.output.json'))
         ctx = open(os.path.join(self.context_folder, 'lambda-context.json'))
@@ -316,9 +342,9 @@ class Test(unittest.TestCase):
         messageConfig = msg.get('messageConfig')
         if 'messageConfig' in msg: del msg['messageConfig']
         result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
-        assert result == out_msg 
-    
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+        assert result == out_msg
+
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value='Example')
     def test_inline_template(self, getCurrentSfnTask_function):
         """ test inline_template.input.json """
         inp = open(os.path.join(self.test_folder, 'inline_template.input.json'))
@@ -327,10 +353,10 @@ class Test(unittest.TestCase):
         out_msg = json.loads(out.read())
 
         msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig');
-        if 'messageConfig' in msg: del msg['messageConfig'];
+        messageConfig = msg.get('messageConfig')
+        if 'messageConfig' in msg: del msg['messageConfig']
         result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
-        assert result == out_msg 
+        assert result == out_msg
 
     def test_templates(self):
         """ test templates.input.json """
@@ -345,7 +371,7 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value='Example')
     def test_cumulus_context(self, getCurrentSfnTask_function):
         """ test storing cumulus_context metadata """
         inp = open(os.path.join(self.test_folder, 'cumulus_context.input.json'))
@@ -365,9 +391,9 @@ class Test(unittest.TestCase):
         schemas = { 'input': 'input.json' }
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["payload"]= { "hello": "world" }
+        in_msg['payload']= { 'hello': 'world' }
         msg = adapter.loadNestedEvent(in_msg, {})
-        assert msg["input"]["hello"] == "world"
+        assert msg['input']['hello'] == 'world'
 
     def test_failing_input_jsonschema(self):
         """ test a failing input schema """
@@ -375,7 +401,7 @@ class Test(unittest.TestCase):
         schemas = { 'input': 'input.json' }
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["payload"]= { "hello": 1 }
+        in_msg['payload']= { 'hello': 1 }
         try:
             adapter.loadNestedEvent(in_msg, {})
         except ValidationError as e:
@@ -389,7 +415,7 @@ class Test(unittest.TestCase):
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
         msg = adapter.loadNestedEvent(in_msg, {})
-        assert msg["config"]["inlinestr"] == 'prefixbarsuffix'
+        assert msg['config']['inlinestr'] == 'prefixbarsuffix'
 
     def test_failing_config_jsonschema(self):
         """ test a failing input schema """
@@ -397,8 +423,8 @@ class Test(unittest.TestCase):
         schemas = { 'config': 'config.json' }
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["workflow_config"]["Example"]["boolean_option"] = '{{$.meta.boolean_option}}'
-        in_msg["meta"]["boolean_option"] = "notgoingtowork"
+        in_msg['workflow_config']['Example']['boolean_option'] = '{{$.meta.boolean_option}}'
+        in_msg['meta']['boolean_option'] = 'notgoingtowork'
         try:
             adapter.loadNestedEvent(in_msg, {})
         except ValidationError as e:
@@ -413,10 +439,10 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         msg = adapter.loadNestedEvent(in_msg, {})
         messageConfig = msg.get('messageConfig')
-        handler_response = { "goodbye": "world" }
+        handler_response = { 'goodbye': 'world' }
         result = adapter.createNextEvent(handler_response, in_msg, messageConfig)
-        assert result["payload"]["goodbye"] == "world"
-    
+        assert result['payload']['goodbye'] == 'world'
+
     def test_failing_output_jsonschema(self):
         """ test a working output schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
@@ -425,7 +451,7 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         msg = adapter.loadNestedEvent(in_msg, {})
         messageConfig = msg.get('messageConfig')
-        handler_response = { "goodbye": 1 }
+        handler_response = { 'goodbye': 1 }
         try:
             adapter.createNextEvent(handler_response, in_msg, messageConfig,)
         except ValidationError as e:


### PR DESCRIPTION
When the message adapter is used as a command line tool (like with js applications) the context object is passed in as a dictionary. When imported into a Python script and used as a module, the context object is of type `LambdaContext` https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html

The way things are currently written, `context.get` calls will break when called from a Python application.

**Changes:**
* check if the `context` object is a dict before doing any kind of operations with it.

**Testing:**
[x] unit tests
[x] manual test with python
[x] unit tests in cumulus-message-adapter-python
[ ] manual test with nodejs
[ ] unit tests in cumulus-message-adapter-js
[ ] manual test with java
[ ] unit tests in cumulus-message-adapter-java