### PR TITLE
pin dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonpath-ng>=1.4.2
-jsonschema>=2.6.0
-boto3>=1.7.74
+jsonpath-ng~=1.4.2
+jsonschema~=2.6.0
+boto3~=1.7.74


### PR DESCRIPTION
* Pin dependencies in `requirements.txt` to compatible versions to avoid broken builds due to upstream dependency changes.