### PR TITLE
Use single braces to wrap object JSONPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+
+- Removed deprecated function `loadRemoteEvent` and updated tests.
+
+### Fixed
+
+- Fixed issue where remote message stored configuration values would overwrite the config params in the step reading the remote message [CUMULUS-1447]
 
 ## [v1.1.0] - 2019-09-16
 

--- a/__main__.py
+++ b/__main__.py
@@ -25,9 +25,7 @@ if __name__ == '__main__':
 
     try:
         context = allInput.get('context')
-        if (functionName == 'loadRemoteEvent'):
-            result = transformer.loadRemoteEvent(event)
-        elif (functionName == 'loadAndUpdateRemoteEvent'):
+        if (functionName == 'loadAndUpdateRemoteEvent'):
             result = transformer.loadAndUpdateRemoteEvent(event, context)
         elif (functionName == 'loadNestedEvent'):
             result = transformer.loadNestedEvent(event, context)

--- a/examples/messages/configured_non_object_remote.input.json
+++ b/examples/messages/configured_non_object_remote.input.json
@@ -4,7 +4,7 @@
       "task_config": {
         "inlinestr": "prefix{meta.foo.someKey}suffix",
         "array": "{[$.meta.foo.someKey]}",
-        "object": "{{$.meta.foo}}"
+        "object": "{$.meta.foo}"
       },
       "cumulus_meta": {
         "message_source": "local",

--- a/examples/messages/configured_non_object_remote.output.json
+++ b/examples/messages/configured_non_object_remote.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo.someKey}suffix",
     "array": "{[$.meta.foo.someKey]}",
-    "object": "{{$.meta.foo}}"
+    "object": "{$.meta.foo}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/examples/messages/configured_remote.input.json
+++ b/examples/messages/configured_remote.input.json
@@ -4,7 +4,7 @@
       "task_config": {
         "inlinestr": "prefix{meta.foo}suffix",
         "array": "{[$.meta.foo]}",
-        "object": "{{$.meta}}"
+        "object": "{$.meta}"
       },
       "cumulus_meta": {
         "message_source": "local",

--- a/examples/messages/configured_remote.output.json
+++ b/examples/messages/configured_remote.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/examples/messages/context.input.json
+++ b/examples/messages/context.input.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta.bar}}"
+    "object": "{$.meta.bar}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/context.output.json
+++ b/examples/messages/context.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta.bar}}"
+    "object": "{$.meta.bar}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/cumulus_context.input.json
+++ b/examples/messages/cumulus_context.input.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/cumulus_context.output.json
+++ b/examples/messages/cumulus_context.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/exception.output.json
+++ b/examples/messages/exception.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/examples/messages/inline_template.input.json
+++ b/examples/messages/inline_template.input.json
@@ -3,7 +3,7 @@
     "inlinestr": "prefix{meta.foo}suffix{meta.foo2}",
     "inlineignore": "prefix{random}should{meta.foo}",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/inline_template.output.json
+++ b/examples/messages/inline_template.output.json
@@ -3,7 +3,7 @@
     "inlinestr": "prefix{meta.foo}suffix{meta.foo2}",
     "inlineignore": "prefix{random}should{meta.foo}",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/jsonpath.input.json
+++ b/examples/messages/jsonpath.input.json
@@ -2,11 +2,11 @@
   "task_config": {
     "bar": "baz",
     "cumulus_message": {
-      "input": "{{$.payload.input}}",
+      "input": "{$.payload.input}",
       "outputs": [
         {
-          "source": "{{$.input.anykey}}",
-          "destination": "{{$.payload.out}}"
+          "source": "{$.input.anykey}",
+          "destination": "{$.payload.out}"
         }
       ]
     }

--- a/examples/messages/jsonpath.output.json
+++ b/examples/messages/jsonpath.output.json
@@ -2,11 +2,11 @@
   "task_config": {
     "bar": "baz",
     "cumulus_message": {
-      "input": "{{$.payload.input}}",
+      "input": "{$.payload.input}",
       "outputs": [
         {
-          "source": "{{$.input.anykey}}",
-          "destination": "{{$.payload.out}}"
+          "source": "{$.input.anykey}",
+          "destination": "{$.payload.out}"
         }
       ]
     }

--- a/examples/messages/meta.input.json
+++ b/examples/messages/meta.input.json
@@ -4,12 +4,12 @@
     "cumulus_message": {
       "outputs": [
         {
-          "source": "{{$}}",
-          "destination": "{{$.payload}}"
+          "source": "{$}",
+          "destination": "{$.payload}"
         },
         {
-          "source": "{{$.input.anykey}}",
-          "destination": "{{$.meta.baz}}"
+          "source": "{$.input.anykey}",
+          "destination": "{$.meta.baz}"
         }
       ]
     }

--- a/examples/messages/meta.output.json
+++ b/examples/messages/meta.output.json
@@ -4,12 +4,12 @@
     "cumulus_message": {
       "outputs": [
         {
-          "source": "{{$}}",
-          "destination": "{{$.payload}}"
+          "source": "{$}",
+          "destination": "{$.payload}"
         },
         {
-          "source": "{{$.input.anykey}}",
-          "destination": "{{$.meta.baz}}"
+          "source": "{$.input.anykey}",
+          "destination": "{$.meta.baz}"
         }
       ]
     }

--- a/examples/messages/remote.output.json
+++ b/examples/messages/remote.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/examples/messages/sfn.input.json
+++ b/examples/messages/sfn.input.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/sfn.output.json
+++ b/examples/messages/sfn.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "sfn",

--- a/examples/messages/templates.input.json
+++ b/examples/messages/templates.input.json
@@ -2,7 +2,7 @@
   "task_config": {
       "inlinestr": "prefix{meta.foo}suffix",
       "array": "{[$.meta.foo]}",
-      "object": "{{$.meta}}"
+      "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/examples/messages/templates.output.json
+++ b/examples/messages/templates.output.json
@@ -2,7 +2,7 @@
   "task_config": {
     "inlinestr": "prefix{meta.foo}suffix",
     "array": "{[$.meta.foo]}",
-    "object": "{{$.meta}}"
+    "object": "{$.meta}"
   },
   "cumulus_meta": {
     "message_source": "local",

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -243,16 +243,16 @@ class message_adapter:
         * @param {*} str A string containing a JSONPath template to resolve
         * @returns {*} The resolved object
         """
-        valueRegex = '^{.*}$'
+        valueRegex = '^{[^\[\]].*}$'
         arrayRegex = '^{\[.*\]}$'
         templateRegex = '{[^}]+}'
 
         if (re.search(valueRegex, str)):
-            matchData = parse(str[1:(len(str)-1)]).find(event)
+            matchData = parse(str.lstrip('{').rstrip('}')).find(event)
             return matchData[0].value if len(matchData) > 0 else None
 
         elif (re.search(arrayRegex, str)):
-            matchData = parse(str[2:(len(str)-2)]).find(event)
+            matchData = parse(str.lstrip('{').rstrip('}').lstrip('[').rstrip(']')).find(event)
             return [item.value for item in matchData] if len(matchData) > 0 else []
 
         elif (re.search(templateRegex, str)):
@@ -409,7 +409,7 @@ class message_adapter:
             for output in outputs:
                 sourcePath = output['source']
                 destPath = output['destination']
-                destJsonPath = destPath[2:(len(destPath)-2)]
+                destJsonPath = destPath.lstrip('{').rstrip('}')
                 value = self.__resolvePathStr(handlerResponse, sourcePath)
                 self.__assignJsonPathValue(result, destJsonPath, value)
         else:

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -243,12 +243,12 @@ class message_adapter:
         * @param {*} str A string containing a JSONPath template to resolve
         * @returns {*} The resolved object
         """
-        valueRegex = '^{{.*}}$'
+        valueRegex = '^{.*}$'
         arrayRegex = '^{\[.*\]}$'
         templateRegex = '{[^}]+}'
 
         if (re.search(valueRegex, str)):
-            matchData = parse(str[2:(len(str)-2)]).find(event)
+            matchData = parse(str[1:(len(str)-1)]).find(event)
             return matchData[0].value if len(matchData) > 0 else None
 
         elif (re.search(arrayRegex, str)):

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -2,7 +2,7 @@ import os
 import json
 import re
 import warnings
-import sys 
+import sys
 
 from datetime import datetime, timedelta
 import uuid
@@ -18,6 +18,7 @@ class message_adapter:
     transforms the cumulus message
     """
     REMOTE_DEFAULT_MAX_SIZE = 0
+    CMA_CONFIG_KEYS = ['ReplaceConfig', 'task_config']
 
     def __init__(self, schemas=None):
         self.schemas = schemas
@@ -93,18 +94,6 @@ class message_adapter:
     #  Input message interpretation  #
     ##################################
 
-    # Events stored externally
-
-    def loadRemoteEvent(self, event):
-        """
-        Maintained for backwards compatibility
-        """
-        warnings.warn(
-            'loadRemoteEvent is deprecated and will be removed in a future version',
-            DeprecationWarning
-        )
-        return self.loadAndUpdateRemoteEvent(event, None)
-
     def __parseParameterConfiguration(self, event):
         parsed_event = event
         if event.get('cma'):
@@ -113,14 +102,8 @@ class message_adapter:
             parsed_event.update(updated_event)
         return parsed_event
 
-    def loadAndUpdateRemoteEvent(self, incoming_event, context):
-        """
-        * Looks at a Cumulus message. If the message has part of its data stored remotely in
-        * S3, fetches that data, otherwise it returns the full message, both cases updated with task metadata
-        * @param {*} event The input Lambda event in the Cumulus message protocol
-        * @returns {*} the full event data
-        """
-        event = self.__parseParameterConfiguration(deepcopy(incoming_event))
+
+    def __loadRemoteEvent(self, event):
         if 'replace' in event:
             local_exception = event.get('exception', None)
             _s3 = s3()
@@ -133,14 +116,34 @@ class message_adapter:
                 replacement_targets = parsed_json_path.find(event)
                 if not replacement_targets or len(replacement_targets) != 1:
                     raise Exception('Remote event configuration target {} invalid'.format(target_json_path))
-                try: 
+                try:
                     replacement_targets[0].value.update(remote_event)
-                except AttributeError: 
+                except AttributeError:
                     parsed_json_path.update(event, remote_event)
 
                 event.pop('replace')
                 if (local_exception and local_exception != 'None') and (not event['exception'] or event['exception'] == 'None'):
                     event['exception'] = local_exception
+        return event
+
+    def loadAndUpdateRemoteEvent(self, incoming_event, context):
+        """
+        * Looks at a Cumulus message. If the message has part of its data stored remotely in
+        * S3, fetches that data, otherwise it returns the full message, both cases updated with task metadata.
+        * If event uses parameterized configuration, converts message into a
+        * Cumulus message and ensures that incoming parameter keys are not overridden
+        * @param {*} event The input Lambda event in the Cumulus message protocol
+        * @returns {*} the full event data
+        """
+        event = deepcopy(incoming_event)
+
+        if incoming_event.get('cma'):
+            cmaEvent = deepcopy(incoming_event)
+            event = self.__loadRemoteEvent(event['cma'].get('event'))
+            cmaEvent['cma']['event'].update(event)
+            event = self.__parseParameterConfiguration(cmaEvent)
+        else:
+            event = self.__loadRemoteEvent(event)
 
         if context and 'meta' in event and 'workflow_tasks' in event['meta']:
             cumulus_meta = event['cumulus_meta']
@@ -436,7 +439,8 @@ class message_adapter:
         target_path = replace_config.get('TargetPath', replace_config['Path'])
         max_size = replace_config.get('MaxSize', self.REMOTE_DEFAULT_MAX_SIZE)
 
-        event.pop('ReplaceConfig')
+        [event.pop(key) for key in self.CMA_CONFIG_KEYS if event.get(key)]
+
         cumulus_meta = deepcopy(event['cumulus_meta'])
         parsed_json_path = parse(source_path)
         replacement_data = parsed_json_path.find(event)
@@ -460,9 +464,9 @@ class message_adapter:
         }
         _s3.Object(s3Bucket, s3Key).put(**s3Params)
 
-        try: 
+        try:
             replacement_data.value.clear()
-        except AttributeError: 
+        except AttributeError:
             parsed_json_path.update(event, '')
 
         remoteConfiguration = {'Bucket': s3Bucket, 'Key': s3Key,

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -77,9 +77,9 @@ class Test(unittest.TestCase):
                 "Example": {
                     "bar": "baz",
                     "cumulus_message": {
-                        "input": "{{$.payload.input}}",
-                        "outputs": [{"source": "{{$.input.anykey}}",
-                                    "destination": "{{$.payload.out}}"}]
+                        "input": "{$.payload.input}",
+                        "outputs": [{"source": "{$.input.anykey}",
+                                    "destination": "{$.payload.out}"}]
                     }
                 }
             },
@@ -92,9 +92,9 @@ class Test(unittest.TestCase):
             'input': {'anykey': 'anyvalue'},
             'config': {'bar': 'baz'},
             'messageConfig': {
-                'input': '{{$.payload.input}}',
-                'outputs': [{'source': '{{$.input.anykey}}',
-                            'destination': '{{$.payload.out}}'}]}
+                'input': '{$.payload.input}',
+                'outputs': [{'source': '{$.input.anykey}',
+                            'destination': '{$.payload.out}'}]}
         }
 
         result = self.cumulus_message_adapter.loadNestedEvent(nested_event_local, {})
@@ -114,9 +114,9 @@ class Test(unittest.TestCase):
             "task_config": {
                 "bar": "baz",
                 "cumulus_message": {
-                    "input": "{{$.payload.input}}",
-                    "outputs": [{"source": "{{$.input.anykey}}",
-                                "destination": "{{$.payload.out}}"}]
+                    "input": "{$.payload.input}",
+                    "outputs": [{"source": "{$.input.anykey}",
+                                "destination": "{$.payload.out}"}]
                 }
             },
             "cumulus_meta": {"message_source": "local", "id": "id-1234"},
@@ -128,9 +128,9 @@ class Test(unittest.TestCase):
             'input': {'anykey': 'anyvalue'},
             'config': {'bar': 'baz'},
             'messageConfig': {
-                'input': '{{$.payload.input}}',
-                'outputs': [{'source': '{{$.input.anykey}}',
-                            'destination': '{{$.payload.out}}'}]}
+                'input': '{$.payload.input}',
+                'outputs': [{'source': '{$.input.anykey}',
+                            'destination': '{$.payload.out}'}]}
         }
 
         result = self.cumulus_message_adapter.loadNestedEvent(nested_event_local, {})
@@ -155,8 +155,8 @@ class Test(unittest.TestCase):
         # messageConfig objects
         message_config_with_simple_outputs = {
             'outputs': [{
-                'source': '{{$.input.dataLocation}}',
-                'destination': '{{$.payload}}'
+                'source': '{$.input.dataLocation}',
+                'destination': '{$.payload}'
             }]
         }
 
@@ -171,8 +171,8 @@ class Test(unittest.TestCase):
         """
         message_config_with_nested_outputs = {
             'outputs': [{
-                'source': '{{$.input.dataLocation}}',
-                'destination': '{{$.payload.dataLocation}}'
+                'source': '{$.input.dataLocation}',
+                'destination': '{$.payload.dataLocation}'
             }]
         }
 
@@ -594,7 +594,7 @@ class Test(unittest.TestCase):
         schemas = { 'config': 'config.json' }
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["task_config"]["boolean_option"] = '{{$.meta.boolean_option}}'
+        in_msg["task_config"]["boolean_option"] = '{$.meta.boolean_option}'
         in_msg["meta"]["boolean_option"] = "notgoingtowork"
         try:
             adapter.loadNestedEvent(in_msg, {})

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -14,10 +14,20 @@ class Test(unittest.TestCase):
     """ Test class """
 
     s3_object = {'input': ':blue_whale:'}
+    config_s3_object = {'task_config' : 'bad value', 'input': ':blue_whale:'}
     bucket_name = 'testing-internal'
     key_name = 'blue_whale-event.json'
+    config_key_name = 'cma_config_blue_whale-event.json'
     event_with_cma = {'cma': {'foo': 'bar', 'event': {'some': 'object'}}}
     event_with_replace = {'replace': {'Bucket': bucket_name, 'Key': key_name, 'TargetPath': '$'}}
+    config_event_with_replace = {'cma':
+                                    {
+                                         'task_config': 'foo_bar',
+                                         'event': {
+                                             'replace': {'Bucket': bucket_name, 'Key': config_key_name, 'TargetPath': '$'}
+                                         }
+                                    }
+                                }
     event_without_replace = {'input': ':baby_whale:'}
     test_uuid = 'aad93279-95d4-4ada-8c43-aa5823f8bbbc'
     next_event_object_key_name = "events/{0}".format(test_uuid)
@@ -37,29 +47,40 @@ class Test(unittest.TestCase):
 
         self.s3.Bucket(self.bucket_name).create()
         self.s3.Object(self.bucket_name, self.key_name).put(Body=json.dumps(self.s3_object))
+        self.s3.Object(self.bucket_name, self.config_key_name).put(Body=json.dumps(self.config_s3_object))
+
 
     def tearDown(self):
         delete_objects_object = {
-            'Objects': [{'Key': self.key_name}, {'Key': self.next_event_object_key_name}]
+            'Objects': [{'Key': self.key_name}, {'Key': self.next_event_object_key_name},
+                        {'Key': self.config_key_name}]
         }
         self.s3.Bucket(self.bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(self.bucket_name).delete()
-
     # loadAndUpdateRemoteEvent tests
     def test_returns_remote_s3_object(self):
         """ Test remote s3 event is returned when 'replace' key is present """
-        result = self.cumulus_message_adapter.loadRemoteEvent(self.event_with_replace)
+        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_with_replace, None)
         assert result == self.s3_object
 
     def test_returns_event(self):
         """ Test event argument is returned when 'replace' key is not present """
-        result = self.cumulus_message_adapter.loadRemoteEvent(self.event_without_replace)
+        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_without_replace, None)
         assert result == self.event_without_replace
 
-    def test_loadAndUpdateRemoteEvent_handles_cma_parameter(self): 
+    def test_loadAndUpdateRemoteEvent_handles_cma_parameter(self):
         """ Test incoming event with 'cma' parameter is assembled into CMA message """
         result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_with_cma, None)
         expected = { 'foo': 'bar', 'some': 'object'}
+        self.assertEqual(expected, result)
+
+
+    def test_loadAndUpdateRemoteEvent_does_not_overwrite_configuration(self):
+        """ Test incoming event with configuration is not overwritten by key in remote event """
+        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.config_event_with_replace, None)
+        expected = {'task_config': self.config_event_with_replace['cma']['task_config'],
+                    'input': u':blue_whale:',
+                    'replace': self.config_event_with_replace['cma']['event']['replace']}
         self.assertEqual(expected, result)
 
     # loadNestedEvent tests
@@ -258,7 +279,7 @@ class Test(unittest.TestCase):
                 'workflow': 'testing',
                 'system_bucket': self.bucket_name
             },
-            'meta': { 
+            'meta': {
                 'another_key': {
                 'some_meta_key': 'some_meta_object'
             }},

--- a/tests/test-program.py
+++ b/tests/test-program.py
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
         return { 'bucket_name': bucket_name, 'key_name': key_name }
-    
+
     def cleanUpRemoteMessage(self, bucket_name, key_name):
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
@@ -59,13 +59,6 @@ class Test(unittest.TestCase):
             'output': 'schemas/exmaples-messages.output.json',
             'config': 'schemas/examples-messages.config.json'
         }
-        # keep to test backwards compatibility
-        allInput = {'event': in_msg, 'schemas': schemas}
-        currentDirectory = os.getcwd()
-        remoteEventCmd = ['python', currentDirectory, 'loadRemoteEvent']
-        (exitstatus, remoteEvent, errorstr) = self.executeCommand( # pylint: disable=unused-variable
-            remoteEventCmd, json.dumps(allInput))
-        assert exitstatus == 0 
 
         allInput = {'event': in_msg, 'context': context, 'schemas': schemas}
         currentDirectory = os.getcwd()
@@ -102,7 +95,7 @@ class Test(unittest.TestCase):
     def test_basic(self):
         """ test basic message """
         self.transformMessages('basic')
-    
+
     def test_exception(self):
         """ test remote message with exception """
         self.transformMessages('exception')


### PR DESCRIPTION
Have `valueRegex` check for single braced JSONPaths instead of double braced entries, which conflicts with handlebars syntax and has led to some ugly hacks.