### PR TITLE
Cumulus 1486

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,6 @@ workflows:
       - publish_pypi:
         requires:
           - publish_github
-          filters:
-            branches:
-              only: master
+        filters:
+          branches:
+            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,8 +147,8 @@ jobs:
       - run:
           name: Deploy to PyPi
           command: |
-            virtualenv ~/venv27
-            . ~/venv27/bin/activate
+            virtualenv ~/venv36
+            . ~/venv36/bin/activate
             pip install twine
             python setup.py sdist
             twine upload --skip-existing --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,8 @@ workflows:
       - build_python38
       - publish_github:
           requires:
-            - build_python38
             - build_python36
+            - build_python38
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
           name: install dependencies
           command: |
             pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv36
-            . ~/venv36/bin/activate
+            ~/.local/bin/virtualenv ~/venv38
+            . ~/venv38/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
             pip install .
@@ -91,7 +91,7 @@ jobs:
           environment:
             LOCALSTACK_HOST: localstack
           command: |
-            . ~/venv36/bin/activate
+            . ~/venv38/bin/activate
             pylint __main__.py -E
             CUMULUS_ENV=testing nosetests -v -s
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,12 @@
 #
 version: 2
 references:
-  container_python27: &container_python27
-    docker:
-      - image: circleci/python:2.7.13
-      - name: localstack
-        image: localstack/localstack
-    working_directory: ~/repo
-
   container_python36: &container_python36
     docker:
       - image: circleci/python:3.6.2
       - name: localstack
         image: localstack/localstack
     working_directory: ~/repo
-
-  # Download and cache dependencies
-  restore_cache_python27: &restore_cache_python27
-    restore_cache:
-      keys:
-        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-        # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
 
   restore_cache_python36: &restore_cache_python36
     restore_cache:
@@ -33,12 +18,6 @@ references:
         # fallback to using the latest cache if no exact match is found
         - v1-dependencies-
 
-  save_cache_python27: &save_cache_python27
-    save_cache:
-      paths:
-        - ~/venv27
-      key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-
   save_cache_python36: &save_cache_python36
     save_cache:
       paths:
@@ -46,30 +25,6 @@ references:
       key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
 jobs:
-  build_python27:
-    <<: *container_python27
-    steps:
-      - checkout
-      - *restore_cache_python27
-      - run:
-          name: install dependencies
-          command: |
-            pip install virtualenv
-            virtualenv ~/venv27
-            . ~/venv27/bin/activate
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-            pip install .
-      - *save_cache_python27
-      - run:
-          name: run tests
-          environment:
-            LOCALSTACK_HOST: localstack
-          command: |
-            . ~/venv27/bin/activate
-            pylint __main__.py -E
-            CUMULUS_ENV=testing nosetests -v -s
-
   build_python36:
     <<: *container_python36
     steps:
@@ -95,7 +50,7 @@ jobs:
             CUMULUS_ENV=testing nosetests -v -s
 
   publish_github:
-    <<: *container_python27
+    <<: *container_python36
     steps:
       - checkout
       - add_ssh_keys
@@ -140,10 +95,10 @@ jobs:
             fi
 
   publish_pypi:
-    <<: *container_python27
+    <<: *container_python36
     steps:
       - checkout
-      - *restore_cache_python27
+      - *restore_cache_python36
       - run:
           name: Deploy to PyPi
           command: |
@@ -155,21 +110,18 @@ jobs:
 
 workflows:
   version: 2
-  build_test_27_publish:
-    jobs:
-      - build_python27
-      - publish_github:
-          requires:
-            - build_python27
-          filters:
-            branches:
-              only: master
-      - publish_pypi:
-          requires:
-            - publish_github
-          filters:
-            branches:
-              only: master
-  build_test_36:
+  build_test_36_publish:
     jobs:
       - build_python36
+      - publish_github:
+        requires:
+          - build_python36
+        filters:
+          branches:
+            only: master
+      - publish_pypi:
+        requires:
+          - publish_github
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             pylint __main__.py -E
             CUMULUS_ENV=testing nosetests -v -s
 
-  build_python36:
+  build_python38:
     <<: *container_python38
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv38
+            /usr/local/bin/virtualenv ~/venv38
             . ~/venv38/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,15 +161,15 @@ workflows:
       - build_python36
       - build_python38
       - publish_github:
-        requires:
-          - build_python38
-          - build_python36
-        filters:
-          branches:
-            only: master
+          requires:
+            - build_python38
+            - build_python36
+          filters:
+            branches:
+              only: master
       - publish_pypi:
-        requires:
-          - publish_github
-        filters:
-          branches:
-            only: master
+          requires:
+            - publish_github
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,26 +24,26 @@ references:
         - ~/venv36
       key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
-  references:
-    container_python38: &container_python38
-      docker:
-        - image: circleci/python:3.8.1
-        - name: localstack
-          image: localstack/localstack
-      working_directory: ~/repo
 
-    restore_cache_python38: &restore_cache_python38
-      restore_cache:
-        keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+  container_python38: &container_python38
+    docker:
+      - image: circleci/python:3.8.1
+      - name: localstack
+        image: localstack/localstack
+    working_directory: ~/repo
 
-    save_cache_python38: &save_cache_python38
-      save_cache:
-        paths:
-          - ~/venv38
-        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+  restore_cache_python38: &restore_cache_python38
+    restore_cache:
+      keys:
+        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+  save_cache_python38: &save_cache_python38
+    save_cache:
+      paths:
+        - ~/venv38
+      key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,6 @@ jobs:
             python setup.py sdist
             twine upload --skip-existing --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*
 
-
 workflows:
   version: 2
   build_test_publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
             python setup.py sdist
             twine upload --skip-existing --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*
 
+
 workflows:
   version: 2
   build_test_publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,28 @@ references:
         - ~/venv36
       key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
+  references:
+    container_python38: &container_python38
+      docker:
+        - image: circleci/python:3.8.1
+        - name: localstack
+          image: localstack/localstack
+      working_directory: ~/repo
+
+    restore_cache_python38: &restore_cache_python38
+      restore_cache:
+        keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+    save_cache_python38: &save_cache_python38
+      save_cache:
+        paths:
+          - ~/venv38
+        key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+
+
 jobs:
   build_python36:
     <<: *container_python36
@@ -40,6 +62,30 @@ jobs:
             pip install -r requirements-dev.txt
             pip install .
       - *save_cache_python36
+      - run:
+          name: run tests
+          environment:
+            LOCALSTACK_HOST: localstack
+          command: |
+            . ~/venv36/bin/activate
+            pylint __main__.py -E
+            CUMULUS_ENV=testing nosetests -v -s
+
+  build_python36:
+    <<: *container_python38
+    steps:
+      - checkout
+      - *restore_cache_python38
+      - run:
+          name: install dependencies
+          command: |
+            pip install --user virtualenv
+            ~/.local/bin/virtualenv ~/venv36
+            . ~/venv36/bin/activate
+            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
+            pip install .
+      - *save_cache_python38
       - run:
           name: run tests
           environment:
@@ -110,11 +156,13 @@ jobs:
 
 workflows:
   version: 2
-  build_test_36_publish:
+  build_test_publish:
     jobs:
       - build_python36
+      - build_python38
       - publish_github:
         requires:
+          - build_python38
           - build_python36
         filters:
           branches:

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,4 +9,4 @@
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-# disable=W0212,R0201,C0103,E1101
+disable=W0212,C0103,C0114

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,4 +9,4 @@
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=W0212,R0201,C0103,E1101
+# disable=W0212,R0201,C0103,E1101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 All notable changes to this project are documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 All notable changes to this project are documented in this file.
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ requirements: dist requirements.txt
 	rm -rf dist/docutils
 
 packaged_runtime: requirements
+	pip install -r requirements-dev.txt
 	cp __main__.py ./dist/
-	pip install pyinstaller
 	pyinstaller --distpath dist_package --clean -F -n cma ./dist/__main__.py
 
 cumulus-message-adapter.zip: requirements packaged_runtime

--- a/__main__.py
+++ b/__main__.py
@@ -5,13 +5,6 @@ import sys
 
 from message_adapter import message_adapter
 
-# use input with both python 2 & 3
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
-
 if __name__ == '__main__':
     functionName = sys.argv[1]
     allInput = json.loads(input())
@@ -26,22 +19,22 @@ if __name__ == '__main__':
     try:
         context = allInput.get('context')
         if (functionName == 'loadAndUpdateRemoteEvent'):
-            result = transformer.loadAndUpdateRemoteEvent(event, context)
+            result = transformer.load_and_update_remote_event(event, context)
         elif (functionName == 'loadNestedEvent'):
-            result = transformer.loadNestedEvent(event, context)
+            result = transformer.load_nested_event(event, context)
         elif (functionName == 'createNextEvent'):
             handlerResponse = allInput['handler_response']
             if 'message_config' in allInput:
                 messageConfig = allInput['message_config']
             else:
                 messageConfig = None
-            result = transformer.createNextEvent(handlerResponse, event, messageConfig)
+            result = transformer.create_next_event(handlerResponse, event, messageConfig)
         if (result is not None and len(result) > 0):
             sys.stdout.write(json.dumps(result))
             sys.stdout.flush()
             exitCode = 0
     except LookupError as le:
         sys.stderr.write("Lookup error: " + str(le))
-    except:
-        sys.stderr.write("Unexpected error:"+ str(sys.exc_info()[0])+ ". " + str(sys.exc_info()[1]))
+    except Exception:  # pylint: disable=broad-except
+        sys.stderr.write(f'Unexpected Error {str(sys.exc_info()[0])}. {str(sys.exc_info()[1])}')
     sys.exit(exitCode)

--- a/__main__.py
+++ b/__main__.py
@@ -3,7 +3,7 @@
 import json
 import sys
 
-from message_adapter import message_adapter
+from message_adapter.message_adapter import MessageAdapter
 
 if __name__ == '__main__':
     functionName = sys.argv[1]
@@ -12,17 +12,17 @@ if __name__ == '__main__':
         schemas = allInput['schemas']
     else:
         schemas = None
-    transformer = message_adapter.message_adapter(schemas)
+    transformer = MessageAdapter(schemas)
     exitCode = 1
     event = allInput['event']
 
     try:
         context = allInput.get('context')
-        if (functionName == 'loadAndUpdateRemoteEvent'):
+        if functionName == 'loadAndUpdateRemoteEvent':
             result = transformer.load_and_update_remote_event(event, context)
-        elif (functionName == 'loadNestedEvent'):
+        elif functionName == 'loadNestedEvent':
             result = transformer.load_nested_event(event, context)
-        elif (functionName == 'createNextEvent'):
+        elif functionName == 'createNextEvent':
             handlerResponse = allInput['handler_response']
             if 'message_config' in allInput:
                 messageConfig = allInput['message_config']

--- a/message_adapter/aws.py
+++ b/message_adapter/aws.py
@@ -3,12 +3,14 @@ import os
 import boto3
 from botocore.config import Config
 
+
 def localhost_s3_url():
+    """ Returns configured LOCALSTACK_HOST url or default for localstack s3 """
     if 'LOCALSTACK_HOST' in os.environ:
-        localhost_s3_url = 'http://%s:4572' % os.environ['LOCALSTACK_HOST']
+        s3_url = 'http://%s:4572' % os.environ['LOCALSTACK_HOST']
     else:
-        localhost_s3_url = 'http://localhost:4572'
-    return localhost_s3_url
+        s3_url = 'http://localhost:4572'
+    return s3_url
 
 
 def s3():
@@ -26,12 +28,13 @@ def s3():
     return boto3.resource('s3')
 
 
-# Localstack doesn't support step functions. This is an interim solution so we
-# don't make requests to the AWS API in testing.
 def stepFn():
+    """Localstack doesn't support step functions. This method is an interim solution so we
+       don't make requests to the AWS API in testing."""
     region = os.getenv('AWS_DEFAULT_REGION', 'us-east-1')
     if ('CUMULUS_ENV' in os.environ) and (os.environ["CUMULUS_ENV"] == 'testing'):
-        return boto3.client(service_name='stepfunctions', endpoint_url=localhost_s3_url(), region_name=region)
+        return boto3.client(service_name='stepfunctions',
+                            endpoint_url=localhost_s3_url(), region_name=region)
     else:
         config = Config(region_name=region, retries=dict(max_attempts=30))
         return boto3.client('stepfunctions', config=config)

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -291,7 +291,6 @@ class MessageAdapter:
             return self.__resolve_path_str(event, config)
 
         if isinstance(config, list):
-            # TODO: Pylint disabled due to missing testing
             for i in range(0, len(config)):  # pylint: disable=consider-using-enumerate
                 config[i] = self.__resolve_config_object(event, config[i])
             return config

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -10,7 +10,8 @@ from jsonpath_ng import parse
 from jsonschema import validate
 from .aws import stepFn, s3
 
-class message_adapter:
+
+class MessageAdapter:
     """
     transforms the cumulus message
     """
@@ -20,37 +21,39 @@ class message_adapter:
     def __init__(self, schemas=None):
         self.schemas = schemas
 
-    def __getSfnExecutionArnByName(self, stateMachineArn, executionName):
+    def __get_sfn_execution_arn_by_name(self, state_machine_arn, execution_name):
         """
         * Given a state machine arn and execution name, returns the execution's ARN
-        * @param {string} stateMachineArn The ARN of the state machine containing the execution
-        * @param {string} executionName The name of the execution
+        * @param {string} state_machine_arn The ARN of the state machine containing the execution
+        * @param {string} execution_name The name of the execution
         * @returns {string} The execution's ARN
         """
-        return (':').join([stateMachineArn.replace(':stateMachine:', ':execution:'), executionName])
+        return (':').join([state_machine_arn.replace(':stateMachine:', ':execution:'),
+                           execution_name])
 
-    def __getTaskNameFromExecutionHistory(self, executionHistory, arn):
+    def __get_task_name_from_execution_history(self, execution_history, arn):
         """
-        * Given an execution history object returned by the StepFunctions API and an optional Activity
-        * or Lambda ARN returns the most recent task name started for the given ARN, or if no ARN is
-        * supplied, the most recent task started.
+        * Given an execution history object returned by the StepFunctions API and an optional
+        * Activity or Lambda ARN returns the most recent task name started for the given ARN,
+        * or if no ARN is supplied, the most recent task started.
         *
-        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started execution
-        * is the desired execution. This WILL BREAK parallel executions, so always supply this if possible.
+        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+        * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+        * this if possible.
         *
-        * @param {dict} executionHistory The execution history returned by getExecutionHistory, assumed
-        *                             to be sorted so most recent executions come last
+        * @param {dict} executionHistory The execution history returned by getExecutionHistory,
+        * assumed to be sorted so most recent executions come last
         * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
         * @throws If no matching task is found
         * @returns {string} The matching task name
         """
-        eventsById = {}
+        events_by_id = {}
 
         # Create a lookup table for finding events by their id
-        for event in executionHistory['events']:
-            eventsById[event['id']] = event
+        for event in execution_history['events']:
+            events_by_id[event['id']] = event
 
-        for step in executionHistory['events']:
+        for step in execution_history['events']:
             # Find the ARN in thie history (the API is awful here).  When found, return its
             # previousEventId's (TaskStateEntered) name
             if (arn is not None and
@@ -58,49 +61,49 @@ class message_adapter:
                       step['lambdaFunctionScheduledEventDetails']['resource'] == arn) or
                      (step['type'] == 'ActivityScheduled' and
                       step['activityScheduledEventDetails']['resource'] == arn)) and
-                    'stateEnteredEventDetails' in eventsById[step['previousEventId']]):
-                return eventsById[step['previousEventId']]['stateEnteredEventDetails']['name']
+                    'stateEnteredEventDetails' in events_by_id[step['previousEventId']]):
+                return events_by_id[step['previousEventId']]['stateEnteredEventDetails']['name']
             elif step['type'] == 'TaskStateEntered':
                 return step['stateEnteredEventDetails']['name']
         raise LookupError('No task found for ' + arn)
 
-    def __getCurrentSfnTask(self, stateMachineArn, executionName, arn):
+    def __get_current_sfn_task(self, state_machine_arn, execution_name, arn):
         """
-        * Given a state machine ARN, an execution name, and an optional Activity or Lambda ARN returns
-        * the most recent task name started for the given ARN in that execution, or if no ARN is
-        * supplied, the most recent task started.
+        * Given a state machine ARN, an execution name, and an optional Activity or Lambda ARN
+        * returns the most recent task name started for the given ARN in that execution,
+        * or if no ARN is supplied, the most recent task started.
         *
-        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started execution
-        * is the desired execution. This WILL BREAK parallel executions, so always supply this if possible.
+        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+        * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+        * this if possible.
         *
-        * @param {string} stateMachineArn The ARN of the state machine containing the execution
-        * @param {string} executionName The name of the step function execution to look up
+        * @param {string} state_machine_arn The ARN of the state machine containing the execution
+        * @param {string} execution_name The name of the step function execution to look up
         * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
         * @returns {string} The name of the task being run
         """
         sfn = stepFn()
-        executionArn = self.__getSfnExecutionArnByName(stateMachineArn, executionName)
-        executionHistory = sfn.get_execution_history(
-            executionArn=executionArn,
+        execution_arn = self.__get_sfn_execution_arn_by_name(state_machine_arn, execution_name)
+        execution_history = sfn.get_execution_history(
+            executionArn=execution_arn,
             maxResults=40,
             reverseOrder=True
         )
-        return self.__getTaskNameFromExecutionHistory(executionHistory, arn)
+        return self.__get_task_name_from_execution_history(execution_history, arn)
 
     ##################################
     #  Input message interpretation  #
     ##################################
 
-    def __parseParameterConfiguration(self, event):
+    def __parse_parameter_configuration(self, event):
         parsed_event = event
         if event.get('cma'):
-            updated_event = {k:v for (k,v) in event['cma'].items() if k != 'event'}
+            updated_event = {k: v for (k, v) in event['cma'].items() if k != 'event'}
             parsed_event = event['cma']['event']
             parsed_event.update(updated_event)
         return parsed_event
 
-
-    def __loadRemoteEvent(self, event):
+    def __load_remote_event(self, event):
         if 'replace' in event:
             local_exception = event.get('exception', None)
             _s3 = s3()
@@ -112,21 +115,23 @@ class message_adapter:
                 remote_event = json.loads(data['Body'].read().decode('utf-8'))
                 replacement_targets = parsed_json_path.find(event)
                 if not replacement_targets or len(replacement_targets) != 1:
-                    raise Exception('Remote event configuration target {} invalid'.format(target_json_path))
+                    raise Exception(f'Remote event configuration target {target_json_path} invalid')
                 try:
                     replacement_targets[0].value.update(remote_event)
                 except AttributeError:
                     parsed_json_path.update(event, remote_event)
 
                 event.pop('replace')
-                if (local_exception and local_exception != 'None') and (not event['exception'] or event['exception'] == 'None'):
+                exception_bool = (local_exception and local_exception != 'None')
+                if exception_bool and (not event['exception'] or event['exception'] == 'None'):
                     event['exception'] = local_exception
         return event
 
     def load_and_update_remote_event(self, incoming_event, context):
         """
         * Looks at a Cumulus message. If the message has part of its data stored remotely in
-        * S3, fetches that data, otherwise it returns the full message, both cases updated with task metadata.
+        * S3, fetches that data, otherwise it returns the full message, both cases updated with
+        * task metadata.
         * If event uses parameterized configuration, converts message into a
         * Cumulus message and ensures that incoming parameter keys are not overridden
         * @param {*} event The input Lambda event in the Cumulus message protocol
@@ -135,39 +140,43 @@ class message_adapter:
         event = deepcopy(incoming_event)
 
         if incoming_event.get('cma'):
-            cmaEvent = deepcopy(incoming_event)
-            event = self.__loadRemoteEvent(event['cma'].get('event'))
-            cmaEvent['cma']['event'].update(event)
-            event = self.__parseParameterConfiguration(cmaEvent)
+            cma_event = deepcopy(incoming_event)
+            event = self.__load_remote_event(event['cma'].get('event'))
+            cma_event['cma']['event'].update(event)
+            event = self.__parse_parameter_configuration(cma_event)
         else:
-            event = self.__loadRemoteEvent(event)
+            event = self.__load_remote_event(event)
 
         if context and 'meta' in event and 'workflow_tasks' in event['meta']:
             cumulus_meta = event['cumulus_meta']
-            taskMeta = {}
-            taskMeta['name'] = context.get('function_name', context.get('functionName'))
-            taskMeta['version'] = context.get('function_version', context.get('functionVersion'))
-            taskMeta['arn'] = context.get('invoked_function_arn', context.get('invokedFunctionArn', context.get('activityArn')))
-            taskName = self.__getCurrentSfnTask(cumulus_meta['state_machine'], cumulus_meta['execution_name'], taskMeta['arn'])
-            event['meta']['workflow_tasks'][taskName] = taskMeta
+            task_meta = {}
+            task_meta['name'] = context.get('function_name', context.get('functionName'))
+            task_meta['version'] = context.get('function_version', context.get('functionVersion'))
+            task_meta['arn'] = context.get('invoked_function_arn',
+                                           context.get('invokedFunctionArn',
+                                                       context.get('activityArn')))
+            task_name = self.__get_current_sfn_task(cumulus_meta['state_machine'],
+                                                    cumulus_meta['execution_name'],
+                                                    task_meta['arn'])
+            event['meta']['workflow_tasks'][task_name] = task_meta
         return event
 
     # Loading task configuration from workload template
 
-    def __getConfig(self, event, taskName):
+    def __get_config(self, event, task_name):
         """
         * Returns the configuration for the task with the given name, or an empty object if no
         * such task is configured.
         * @param {*} event An event in the Cumulus message format with remote parts resolved
-        * @param {*} taskName The name of the Cumulus task
+        * @param {*} task_name The name of the Cumulus task
         * @returns {*} The configuration object
         """
         config = {}
-        if ('workflow_config' in event and taskName in event['workflow_config']):
-            config = event['workflow_config'][taskName]
+        if ('workflow_config' in event and task_name in event['workflow_config']):
+            config = event['workflow_config'][task_name]
         return config
 
-    def __loadStepFunctionTaskName(self, event, context):
+    def __load_step_function_task_name(self, event, context):
         """
         * For StepFunctions, returns the configuration corresponding to the current execution
         * @param {*} event An event in the Cumulus message format with remote parts resolved
@@ -179,34 +188,34 @@ class message_adapter:
             arn = context['invokedFunctionArn']
         else:
             arn = context.get('invoked_function_arn', context.get('activityArn'))
-        return self.__getCurrentSfnTask(meta['state_machine'], meta['execution_name'], arn)
+        return self.__get_current_sfn_task(meta['state_machine'], meta['execution_name'], arn)
 
-    def __loadConfig(self, event, context):
+    def __load_config(self, event, context):
         """
         * Given a Cumulus message and context, returns the config object for the task
         * @param {*} event An event in the Cumulus message format with remote parts resolved
         * @param {*} context The context object passed to AWS Lambda or containing an activityArn
         * @returns {*} The task's configuration
         """
-        if ('task_config' in event):
+        if 'task_config' in event:
             return event['task_config']
         # Maintained for backwards compatibility
         source = event['cumulus_meta']['message_source']
-        if (source is None):
+        if source is None:
             raise LookupError('cumulus_meta requires a message_source')
-        elif (source == 'local'):
-            taskName = event['cumulus_meta']['task']
-        elif (source == 'sfn'):
-            taskName = self.__loadStepFunctionTaskName(event, context)
+        elif source == 'local':
+            task_name = event['cumulus_meta']['task']
+        elif source == 'sfn':
+            task_name = self.__load_step_function_task_name(event, context)
         else:
             raise LookupError('Unknown event source: ' + source)
-        return self.__getConfig(event, taskName) if taskName is not None else None
+        return self.__get_config(event, task_name) if task_name is not None else None
 
     def __get_jsonschema(self, schema_type):
         schemas = self.schemas
         root_dir = os.environ.get("LAMBDA_TASK_ROOT", '')
         has_schema = schemas and schemas.get(schema_type)
-        rel_filepath = schemas.get(schema_type) if has_schema else 'schemas/{}.json'.format(schema_type)
+        rel_filepath = schemas.get(schema_type) if has_schema else f'schemas/{schema_type}.json'
         filepath = os.path.join(root_dir, rel_filepath)
         return filepath if os.path.exists(filepath) else None
 
@@ -219,12 +228,12 @@ class message_adapter:
             schema = json.load(open(schema_filepath))
             try:
                 validate(document, schema)
-            except Exception as e:
-                e.message = '{} schema: {}'.format(schema_type, e.message)
-                raise e
+            except Exception as exception:
+                exception.message = '{} schema: {}'.format(schema_type, str(exception))
+                raise exception
 
     # Config templating
-    def __resolvePathStr(self, event, jsonPathString):
+    def __resolve_path_str(self, event, json_path_string):
         """
         * Given a Cumulus message (AWS Lambda event) and a string containing a JSONPath
         * template to interpret, returns the result of interpreting that template.
@@ -240,33 +249,33 @@ class message_adapter:
         * It's likely we'll need some sort of bracket-escaping at some point down the line
         *
         * @param {*} event The Cumulus message
-        * @param {*} jsonPathString A string containing a JSONPath template to resolve
+        * @param {*} json_path_string A string containing a JSONPath template to resolve
         * @returns {*} The resolved object
         """
-        valueRegex = r"^{[^\[\]].*}$"
-        arrayRegex = r"^{\[.*\]}$"
-        templateRegex = '{[^}]+}'
+        value_regex = r"^{[^\[\]].*}$"
+        array_regex = r"^{\[.*\]}$"
+        template_regex = '{[^}]+}'
 
-        if re.search(valueRegex, jsonPathString):
-            matchData = parse(jsonPathString.lstrip('{').rstrip('}')).find(event)
-            return matchData[0].value if matchData else None
+        if re.search(value_regex, json_path_string):
+            match_data = parse(json_path_string.lstrip('{').rstrip('}')).find(event)
+            return match_data[0].value if match_data else None
 
-        elif re.search(arrayRegex, jsonPathString):
-            parsedJsonPath = jsonPathString.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
-            matchData = parse(parsedJsonPath).find(event)
-            return [item.value for item in matchData] if matchData else []
+        elif re.search(array_regex, json_path_string):
+            parsed_json_path = json_path_string.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
+            match_data = parse(parsed_json_path).find(event)
+            return [item.value for item in match_data] if match_data else []
 
-        elif re.search(templateRegex, jsonPathString):
-            matches = re.findall(templateRegex, jsonPathString)
+        elif re.search(template_regex, json_path_string):
+            matches = re.findall(template_regex, json_path_string)
             for match in matches:
-                matchData = parse(match.lstrip('{').rstrip('}')).find(event)
-                if matchData:
-                    jsonPathString = jsonPathString.replace(match, matchData[0].value)
-            return jsonPathString
+                match_data = parse(match.lstrip('{').rstrip('}')).find(event)
+                if match_data:
+                    json_path_string = json_path_string.replace(match, match_data[0].value)
+            return json_path_string
 
-        return jsonPathString
+        return json_path_string
 
-    def __resolveConfigObject(self, event, config):
+    def __resolve_config_object(self, event, config):
         """
         * Recursive helper for resolveConfigTemplates
         *
@@ -277,29 +286,25 @@ class message_adapter:
         * @param {*} config A config object, containing paths
         * @returns {*} A config object with all JSONPaths resolved
         """
-        try:
-            unicode
-        except NameError:
-            if isinstance(config, str):
-                return self.__resolvePathStr(event, config)
-        else:
-            if isinstance(config, unicode):
-                return self.__resolvePathStr(event, config)
+
+        if isinstance(config, str):
+            return self.__resolve_path_str(event, config)
 
         if isinstance(config, list):
-            for i in range(0, len(config)):
-                config[i] = self.__resolveConfigObject(event, config[i])
+            # TODO: Pylint disabled due to missing testing
+            for i in range(0, len(config)):  # pylint: disable=consider-using-enumerate
+                config[i] = self.__resolve_config_object(event, config[i])
             return config
 
         elif (config is not None and isinstance(config, dict)):
             result = {}
             for key in config.keys():
-                result[key] = self.__resolveConfigObject(event, config[key])
+                result[key] = self.__resolve_config_object(event, config[key])
             return result
 
         return config
 
-    def __resolveConfigTemplates(self, event, config):
+    def __resolve_config_templates(self, event, config):
         """
         * Given a config object containing possible JSONPath-templated values, resolves
         * all the values in the object using JSONPaths into the provided event.
@@ -308,13 +313,13 @@ class message_adapter:
         * @param {*} config A config object, containing paths
         * @returns {*} A config object with all JSONPaths resolved
         """
-        taskConfig = config.copy()
-        if 'cumulus_message' in taskConfig:
-            del taskConfig['cumulus_message']
-        return self.__resolveConfigObject(event, taskConfig)
+        task_config = config.copy()
+        if 'cumulus_message' in task_config:
+            del task_config['cumulus_message']
+        return self.__resolve_config_object(event, task_config)
 
     # Payload determination
-    def __resolveInput(self, event, config):
+    def __resolve_input(self, event, config):
         """
         * Given a Cumulus message and its config, returns the input object to send to the
         * task, as defined under config.cumulus_message
@@ -323,8 +328,8 @@ class message_adapter:
         * @returns {*} The object to place on the input key of the task's event
         """
         if ('cumulus_message' in config and 'input' in config['cumulus_message']):
-            inputPath = config['cumulus_message']['input']
-            return self.__resolvePathStr(event, inputPath)
+            input_path = config['cumulus_message']['input']
+            return self.__resolve_path_str(event, input_path)
         return event.get('payload')
 
     def load_nested_event(self, event, context):
@@ -334,14 +339,14 @@ class message_adapter:
         * @param {*} event The input message sent to the Lambda
         * @returns {*} message that is ready to pass to an inner task
         """
-        config = self.__loadConfig(event, context)
-        finalConfig = self.__resolveConfigTemplates(event, config)
-        finalPayload = self.__resolveInput(event, config)
-        response = {'input': finalPayload}
-        self.__validate_json(finalPayload, 'input')
-        self.__validate_json(finalConfig, 'config')
-        if finalConfig is not None:
-            response['config'] = finalConfig
+        config = self.__load_config(event, context)
+        final_config = self.__resolve_config_templates(event, config)
+        final_payload = self.__resolve_input(event, config)
+        response = {'input': final_payload}
+        self.__validate_json(final_payload, 'input')
+        self.__validate_json(final_config, 'config')
+        if final_config is not None:
+            response['config'] = final_config
         if 'cumulus_message' in config:
             response['messageConfig'] = config['cumulus_message']
 
@@ -356,7 +361,8 @@ class message_adapter:
 
             # add attribute cumulus_context
             if 'cumulus_context' in event['cumulus_meta']:
-                response['cumulus_config']['cumulus_context'] = event['cumulus_meta']['cumulus_context']
+                cumulus_context = event['cumulus_meta']['cumulus_context']
+                response['cumulus_config']['cumulus_context'] = cumulus_context
 
             if not response['cumulus_config']:
                 del response['cumulus_config']
@@ -367,7 +373,7 @@ class message_adapter:
     # Output message creation   #
     #############################
 
-    def __assignJsonPathValue(self, message, jspath, value):
+    def __assign_json_path_value(self, message, jspath, value):
         """
         * Assign (update or insert) a value to message based on jsonpath.
         * Create the keys if jspath doesn't already exist in the message. In this case, we
@@ -377,46 +383,46 @@ class message_adapter:
         """
         if not parse(jspath).find(message):
             paths = jspath.lstrip('$.').split('.')
-            currentItem = message
-            keyNotFound = False
+            current_item = message
+            key_not_found = False
             for path in paths:
-                if keyNotFound or path not in currentItem:
-                    keyNotFound = True
-                    newPathDict = {}
+                if key_not_found or path not in current_item:
+                    key_not_found = True
+                    new_path_dict = {}
                     # Add missing key to existing dict
-                    currentItem[path] = newPathDict
+                    current_item[path] = new_path_dict
                     # Set current item to newly created dict
-                    currentItem = newPathDict
+                    current_item = new_path_dict
                 else:
-                    currentItem = currentItem[path]
+                    current_item = current_item[path]
         parse(jspath).update(message, value)
         return message
 
-    def __assignOutputs(self, handlerResponse, event, messageConfig):
+    def __assign_outputs(self, handler_response, event, message_config):
         """
         * Applies a task's return value to an output message as defined in config.cumulus_message
         *
-        * @param {*} handlerResponse The task's return value
+        * @param {*} handler_response The task's return value
         * @param {*} event The output message to apply the return value to
         * @param {*} messageConfig The cumulus_message configuration
         * @returns {*} The output message with the nested response applied
         """
         result = deepcopy(event)
-        if messageConfig is not None and 'outputs' in messageConfig:
-            outputs = messageConfig['outputs']
+        if message_config is not None and 'outputs' in message_config:
+            outputs = message_config['outputs']
             result['payload'] = {}
             for output in outputs:
-                sourcePath = output['source']
-                destPath = output['destination']
-                destJsonPath = destPath.lstrip('{').rstrip('}')
-                value = self.__resolvePathStr(handlerResponse, sourcePath)
-                self.__assignJsonPathValue(result, destJsonPath, value)
+                source_path = output['source']
+                dest_path = output['destination']
+                dest_json_path = dest_path.lstrip('{').rstrip('}')
+                value = self.__resolve_path_str(handler_response, source_path)
+                self.__assign_json_path_value(result, dest_json_path, value)
         else:
-            result['payload'] = handlerResponse
+            result['payload'] = handler_response
 
         return result
 
-    def __storeRemoteResponse(self, incoming_event):
+    def __store_remote_response(self, incoming_event):
         """
         * Stores part of a response message in S3 if it is too big to send to StepFunctions
         * @param {*} event The response message
@@ -424,7 +430,7 @@ class message_adapter:
         """
         event = deepcopy(incoming_event)
         replace_config = event.get('ReplaceConfig', None)
-        if not (replace_config):
+        if not replace_config:
             return event
 
         # Set default value if FullMessage flag set
@@ -435,7 +441,9 @@ class message_adapter:
         target_path = replace_config.get('TargetPath', replace_config['Path'])
         max_size = replace_config.get('MaxSize', self.REMOTE_DEFAULT_MAX_SIZE)
 
-        [event.pop(key) for key in self.CMA_CONFIG_KEYS if event.get(key)]
+        for key in self.CMA_CONFIG_KEYS:
+            if event.get(key):
+                del event[key]
 
         cumulus_meta = deepcopy(event['cumulus_meta'])
         parsed_json_path = parse(source_path)
@@ -452,39 +460,39 @@ class message_adapter:
             return event
 
         _s3 = s3()
-        s3Bucket = event['cumulus_meta']['system_bucket']
-        s3Key = ('/').join(['events', str(uuid.uuid4())])
-        s3Params = {
+        s3_bucket = event['cumulus_meta']['system_bucket']
+        s3_key = ('/').join(['events', str(uuid.uuid4())])
+        s3_params = {
             'Expires': datetime.utcnow() + timedelta(days=7),  # Expire in a week
             'Body': json.dumps(replacement_data.value)
         }
-        _s3.Object(s3Bucket, s3Key).put(**s3Params)
+        _s3.Object(s3_bucket, s3_key).put(**s3_params)
 
         try:
             replacement_data.value.clear()
         except AttributeError:
             parsed_json_path.update(event, '')
 
-        remoteConfiguration = {'Bucket': s3Bucket, 'Key': s3Key,
-                               'TargetPath': target_path}
+        remote_configuration = {'Bucket': s3_bucket, 'Key': s3_key,
+                                'TargetPath': target_path}
         event['cumulus_meta'] = event.get('cumulus_meta', cumulus_meta)
-        event['replace'] = remoteConfiguration
+        event['replace'] = remote_configuration
         return event
 
-    def create_next_event(self, handlerResponse, event, messageConfig):
+    def create_next_event(self, handler_response, event, message_config):
         """
         * Creates the output message returned by a task
         *
-        * @param {*} handlerResponse The response returned by the inner task code
+        * @param {*} handler_response The response returned by the inner task code
         * @param {*} event The input message sent to the Lambda
-        * @param {*} messageConfig The cumulus_message object configured for the task
+        * @param {*} message_config The cumulus_message object configured for the task
         * @returns {*} the output message to be returned
         """
-        self.__validate_json(handlerResponse, 'output')
+        self.__validate_json(handler_response, 'output')
 
-        result = self.__assignOutputs(handlerResponse, event, messageConfig)
+        result = self.__assign_outputs(handler_response, event, message_config)
         if not result.get('exception'):
             result['exception'] = 'None'
         if 'replace' in result:
             del result['replace']
-        return self.__storeRemoteResponse(result)
+        return self.__store_remote_response(result)

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -229,7 +229,7 @@ class MessageAdapter:
             try:
                 validate(document, schema)
             except Exception as exception:
-                exception.message = '{} schema: {}'.format(schema_type, str(exception))
+                exception.message = f'{schema_type} schema: {str(exception)}'
                 raise exception
 
     # Config templating
@@ -449,7 +449,7 @@ class MessageAdapter:
         parsed_json_path = parse(source_path)
         replacement_data = parsed_json_path.find(event)
         if len(replacement_data) != 1:
-            raise Exception('JSON path invalid: {}'.format(parsed_json_path))
+            raise Exception(f'JSON path invalid: {parsed_json_path}')
         replacement_data = replacement_data[0]
 
         estimated_data_size = len(json.dumps(replacement_data.value))

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -123,7 +123,7 @@ class message_adapter:
                     event['exception'] = local_exception
         return event
 
-    def loadAndUpdateRemoteEvent(self, incoming_event, context):
+    def load_and_update_remote_event(self, incoming_event, context):
         """
         * Looks at a Cumulus message. If the message has part of its data stored remotely in
         * S3, fetches that data, otherwise it returns the full message, both cases updated with task metadata.
@@ -252,7 +252,7 @@ class message_adapter:
             return matchData[0].value if matchData else None
 
         elif re.search(arrayRegex, jsonPathString):
-            parsedJsonPath = jsonPathString.lstrip('{').rstrip('}').lstrip('[').rstrip(']');
+            parsedJsonPath = jsonPathString.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
             matchData = parse(parsedJsonPath).find(event)
             return [item.value for item in matchData] if matchData else []
 
@@ -327,7 +327,7 @@ class message_adapter:
             return self.__resolvePathStr(event, inputPath)
         return event.get('payload')
 
-    def loadNestedEvent(self, event, context):
+    def load_nested_event(self, event, context):
         """
         * Interprets an incoming event as a Cumulus workflow message
         *
@@ -471,7 +471,7 @@ class message_adapter:
         event['replace'] = remoteConfiguration
         return event
 
-    def createNextEvent(self, handlerResponse, event, messageConfig):
+    def create_next_event(self, handlerResponse, event, messageConfig):
         """
         * Creates the output message returned by a task
         *

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 nose>=1.3
 mock~=1.3
 pylint>=1.8.2
+flake8~=3.7.9
+autopep8~=1.5.0
 pyinstaller~=3.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ mock~=1.3
 pylint>=1.8.2
 flake8~=3.7.9
 autopep8~=1.5.0
-pyinstaller~=3.5.0
+jsonschema==2.6.0
+pyinstaller==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-jsonpath-ng>=1.4.2
-jsonschema~=2.6.0
-boto3>=1.7.74
+jsonpath-ng~=1.4.2
+jsonschema==2.6.0
+boto3~=1.7.74
 six~=1.12.0
 typed-ast>=1.3.0; implementation_name == "cpython"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonpath-ng>=1.4.2
 jsonschema~=2.6.0
 boto3>=1.7.74
-six~=1.11.0
+six~=1.12.0
 typed-ast>=1.3.0; implementation_name == "cpython"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,11 @@ https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
 
+import imp
+
+from os import path
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
-from codecs import open
-from os import path
-import imp
 
 here = path.abspath(path.dirname(__file__))
 
@@ -39,7 +38,8 @@ setup(
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
-    description='A command-line interface for preparing and outputting Cumulus Messages for Cumulus Tasks',  # Required
+    description=('A command-line interface for preparing and outputting '
+                 'Cumulus Messages for Cumulus Tasks'),  # Required
     long_description=long_description,  # Optional
     url='https://github.com/nasa/cumulus-message-adapter',  # Optional
     author='Cumulus Authors',  # Optional

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,12 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     keywords='nasa cumulus message adapter',  # Optional
     packages=find_packages(exclude=['.circleci', 'contrib', 'docs', 'tests']),  # Required
     install_requires=install_requires,
+    python_requires='~=3.6',
     dependency_links=dependency_links
 )

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -11,23 +11,25 @@ from message_adapter import aws, message_adapter
 
 
 class Test(unittest.TestCase):
+    # pylint: disable=no-member, protected-access
     """ Test class """
 
     s3_object = {'input': ':blue_whale:'}
-    config_s3_object = {'task_config' : 'bad value', 'input': ':blue_whale:'}
+    config_s3_object = {'task_config': 'bad value', 'input': ':blue_whale:'}
     bucket_name = 'testing-internal'
     key_name = 'blue_whale-event.json'
     config_key_name = 'cma_config_blue_whale-event.json'
     event_with_cma = {'cma': {'foo': 'bar', 'event': {'some': 'object'}}}
     event_with_replace = {'replace': {'Bucket': bucket_name, 'Key': key_name, 'TargetPath': '$'}}
-    config_event_with_replace = {'cma':
-                                    {
-                                         'task_config': 'foo_bar',
-                                         'event': {
-                                             'replace': {'Bucket': bucket_name, 'Key': config_key_name, 'TargetPath': '$'}
-                                         }
-                                    }
-                                }
+    config_event_with_replace = {
+        'cma':
+            {
+                'task_config': 'foo_bar',
+                'event': {
+                    'replace': {'Bucket': bucket_name, 'Key': config_key_name, 'TargetPath': '$'}
+                }
+            }
+    }
     event_without_replace = {'input': ':baby_whale:'}
     test_uuid = 'aad93279-95d4-4ada-8c43-aa5823f8bbbc'
     next_event_object_key_name = "events/{0}".format(test_uuid)
@@ -47,8 +49,9 @@ class Test(unittest.TestCase):
 
         self.s3.Bucket(self.bucket_name).create()
         self.s3.Object(self.bucket_name, self.key_name).put(Body=json.dumps(self.s3_object))
-        self.s3.Object(self.bucket_name, self.config_key_name).put(Body=json.dumps(self.config_s3_object))
-
+        self.s3.Object(self.bucket_name, self.config_key_name).put(
+            Body=json.dumps(self.config_s3_object)
+        )
 
     def tearDown(self):
         delete_objects_object = {
@@ -57,36 +60,41 @@ class Test(unittest.TestCase):
         }
         self.s3.Bucket(self.bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(self.bucket_name).delete()
-    # loadAndUpdateRemoteEvent tests
+    # load_and_update_remote_event tests
+
     def test_returns_remote_s3_object(self):
         """ Test remote s3 event is returned when 'replace' key is present """
-        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_with_replace, None)
+        result = self.cumulus_message_adapter.load_and_update_remote_event(
+            self.event_with_replace, None)
         assert result == self.s3_object
 
     def test_returns_event(self):
         """ Test event argument is returned when 'replace' key is not present """
-        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_without_replace, None)
+        result = self.cumulus_message_adapter.load_and_update_remote_event(
+            self.event_without_replace, None)
         assert result == self.event_without_replace
 
-    def test_loadAndUpdateRemoteEvent_handles_cma_parameter(self):
+    def test_load_and_update_remote_event_handles_cma_parameter(self):
         """ Test incoming event with 'cma' parameter is assembled into CMA message """
-        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.event_with_cma, None)
-        expected = { 'foo': 'bar', 'some': 'object'}
+        result = self.cumulus_message_adapter.load_and_update_remote_event(
+            self.event_with_cma, None)
+        expected = {'foo': 'bar', 'some': 'object'}
         self.assertEqual(expected, result)
 
-
-    def test_loadAndUpdateRemoteEvent_does_not_overwrite_configuration(self):
+    def test_load_and_update_remote_event_does_not_overwrite_configuration(self):
         """ Test incoming event with configuration is not overwritten by key in remote event """
-        result = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(self.config_event_with_replace, None)
+        result = self.cumulus_message_adapter.load_and_update_remote_event(
+            self.config_event_with_replace, None)
         expected = {'task_config': self.config_event_with_replace['cma']['task_config'],
                     'input': u':blue_whale:',
                     'replace': self.config_event_with_replace['cma']['event']['replace']}
         self.assertEqual(expected, result)
 
-    # loadNestedEvent tests
-    def test_returns_loadNestedEvent_local(self):
+    # load_nested_event tests
+    def test_returns_load_nested_event_local(self):
         """
-        Test returns 'config', 'input' and 'messageConfig' in expected format (workflow_config backwards compatible)
+        Test returns 'config', 'input' and 'messageConfig' in expected format (workflow_config
+        backwards compatible)
         - 'input' in return value is from 'payload' in first argument object
         - 'config' in return value is the task ($.cumulus_meta.task) configuration
            with 'cumulus_message' excluded
@@ -100,7 +108,7 @@ class Test(unittest.TestCase):
                     "cumulus_message": {
                         "input": "{$.payload.input}",
                         "outputs": [{"source": "{$.input.anykey}",
-                                    "destination": "{$.payload.out}"}]
+                                     "destination": "{$.payload.out}"}]
                     }
                 }
             },
@@ -115,16 +123,17 @@ class Test(unittest.TestCase):
             'messageConfig': {
                 'input': '{$.payload.input}',
                 'outputs': [{'source': '{$.input.anykey}',
-                            'destination': '{$.payload.out}'}]}
+                             'destination': '{$.payload.out}'}]}
         }
 
-        result = self.cumulus_message_adapter.loadNestedEvent(nested_event_local, {})
+        result = self.cumulus_message_adapter.load_nested_event(nested_event_local, {})
         assert result == nested_event_local_return
 
-    # loadNestedEvent task_config tests
-    def test_returns_loadNestedEvent_local_with_task_config(self):
+    # load_nested_event task_config tests
+    def test_returns_load_nested_event_local_with_task_config(self):
         """
-        Test returns 'config', 'input' and 'messageConfig' in expected format from task_config with no taskName
+        Test returns 'config', 'input' and 'messageConfig' in expected format from task_config with
+        no taskName
         - 'input' in return value is from 'payload' in first argument object
         - 'config' in return value is the task ($.task_config) configuration
            with 'cumulus_message' excluded
@@ -137,7 +146,7 @@ class Test(unittest.TestCase):
                 "cumulus_message": {
                     "input": "{$.payload.input}",
                     "outputs": [{"source": "{$.input.anykey}",
-                                "destination": "{$.payload.out}"}]
+                                 "destination": "{$.payload.out}"}]
                 }
             },
             "cumulus_meta": {"message_source": "local", "id": "id-1234"},
@@ -151,23 +160,23 @@ class Test(unittest.TestCase):
             'messageConfig': {
                 'input': '{$.payload.input}',
                 'outputs': [{'source': '{$.input.anykey}',
-                            'destination': '{$.payload.out}'}]}
+                             'destination': '{$.payload.out}'}]}
         }
 
-        result = self.cumulus_message_adapter.loadNestedEvent(nested_event_local, {})
+        result = self.cumulus_message_adapter.load_nested_event(nested_event_local, {})
         assert result == nested_event_local_return
 
     # assignOutputs tests
     def test_result_payload_without_config(self):
         """ Test nestedResponse is returned when no config argument is passed """
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs( # pylint: disable=no-member
+        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
             self.nested_response, {}, None)
         assert result['payload'] == self.nested_response
 
     def test_result_payload_without_config_outputs(self):
         """ Test nestedResponse is returned when config has no outputs key/value """
         message_config_without_outputs = {}
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs( # pylint: disable=no-member
+        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
             self.nested_response, {}, message_config_without_outputs)
         assert result['payload'] == self.nested_response
 
@@ -181,7 +190,7 @@ class Test(unittest.TestCase):
             }]
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs( # pylint: disable=no-member
+        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
             self.nested_response, {}, message_config_with_simple_outputs)
         assert result['payload'] == 's3://source.jpg'
 
@@ -197,7 +206,7 @@ class Test(unittest.TestCase):
             }]
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs( # pylint: disable=no-member
+        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
             self.nested_response, {}, message_config_with_nested_outputs)
         assert result['payload'] == {'dataLocation': 's3://source.jpg'}
 
@@ -219,25 +228,25 @@ class Test(unittest.TestCase):
             }
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs( # pylint: disable=no-member
+        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
             self.nested_response, event, message_config_with_nested_outputs)
         assert result['test'] == {
             'dataLocation': 's3://source.jpg',
             'key': 'value'
         }
 
-    # createNextEvent tests
+    # create_next_event tests
     def test_with_replace(self):
         """
-        Test 'replace' key is deleted from value returned from createNextEvent
+        Test 'replace' key is deleted from value returned from create_next_event
         """
-        result = self.cumulus_message_adapter.createNextEvent(
+        result = self.cumulus_message_adapter.create_next_event(
             self.nested_response, self.event_with_replace, None)
         assert 'replace' not in result
 
     def test_small_result_returns_event(self):
         """ Test return result is the event result when it's not too big """
-        result = self.cumulus_message_adapter.createNextEvent(
+        result = self.cumulus_message_adapter.create_next_event(
             self.nested_response, self.event_without_replace, None)
         expected_result = {
             'input': ':baby_whale:',
@@ -247,7 +256,6 @@ class Test(unittest.TestCase):
             }
         }
         assert result == expected_result
-
 
     @patch('uuid.uuid4')
     def test_configured_big_result_stored_remotely(self, uuid_mock):
@@ -283,7 +291,7 @@ class Test(unittest.TestCase):
         }
 
         uuid_mock.return_value = self.test_uuid
-        create_next_event_result = self.cumulus_message_adapter.createNextEvent(
+        create_next_event_result = self.cumulus_message_adapter.create_next_event(
             self.nested_response, event_with_ingest, None)
 
         remote_event = self.s3.Object(self.bucket_name, self.next_event_object_key_name).get()
@@ -306,8 +314,8 @@ class Test(unittest.TestCase):
             },
             'meta': {
                 'another_key': {
-                'some_meta_key': 'some_meta_object'
-            }},
+                    'some_meta_key': 'some_meta_object'
+                }},
             'ReplaceConfig': {
                 'Path': '$.meta.another_key.some_meta_key',
                 'MaxSize': 1,
@@ -333,7 +341,7 @@ class Test(unittest.TestCase):
         expected_remote_event_object = 'some_meta_object'
 
         uuid_mock.return_value = self.test_uuid
-        create_next_event_result = self.cumulus_message_adapter.createNextEvent(
+        create_next_event_result = self.cumulus_message_adapter.create_next_event(
             self.nested_response, event_with_ingest, None)
 
         remote_event = self.s3.Object(self.bucket_name, self.next_event_object_key_name).get()
@@ -378,7 +386,7 @@ class Test(unittest.TestCase):
         }
 
         uuid_mock.return_value = self.test_uuid
-        create_next_event_result = self.cumulus_message_adapter.createNextEvent(
+        create_next_event_result = self.cumulus_message_adapter.create_next_event(
             self.nested_response, event_with_ingest, None)
 
         remote_event = self.s3.Object(self.bucket_name, self.next_event_object_key_name).get()
@@ -395,10 +403,11 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
     def test_exception(self):
@@ -411,15 +420,17 @@ class Test(unittest.TestCase):
         bucket_name = in_msg['replace']['Bucket']
         key_name = in_msg['replace']['Key']
         data_filename = os.path.join(self.test_folder, key_name)
-        with open(data_filename, 'r') as f: datasource = json.load(f)
+        with open(data_filename, 'r') as file_data:
+            datasource = json.load(file_data)
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
 
-        remoteEvent = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, {})
-        msg = self.cumulus_message_adapter.loadNestedEvent(remoteEvent, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, remoteEvent, messageConfig)
+        remote_event= self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
+        msg = self.cumulus_message_adapter.load_nested_event(remote_event, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, remote_event, message_config)
 
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
@@ -433,10 +444,11 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
     def test_meta(self):
@@ -446,10 +458,11 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
     def test_remote(self):
@@ -462,15 +475,17 @@ class Test(unittest.TestCase):
         bucket_name = in_msg['replace']['Bucket']
         key_name = in_msg['replace']['Key']
         data_filename = os.path.join(self.test_folder, key_name)
-        with open(data_filename, 'r') as f: datasource = json.load(f)
+        with open(data_filename, 'r') as file_data:
+            datasource = json.load(file_data)
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
 
-        remoteEvent = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, {})
-        msg = self.cumulus_message_adapter.loadNestedEvent(remoteEvent, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, remoteEvent, messageConfig)
+        remote_event = self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
+        msg = self.cumulus_message_adapter.load_nested_event(remote_event, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, remote_event, message_config)
 
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
@@ -487,21 +502,22 @@ class Test(unittest.TestCase):
         bucket_name = in_msg['cma']['event']['replace']['Bucket']
         key_name = in_msg['cma']['event']['replace']['Key']
         data_filename = os.path.join(self.test_folder, key_name)
-        with open(data_filename, 'r') as f: datasource = json.load(f)
+        with open(data_filename, 'r') as file_data:
+            datasource = json.load(file_data)
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
 
-        remoteEvent = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, {})
-        msg = self.cumulus_message_adapter.loadNestedEvent(remoteEvent, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, remoteEvent, messageConfig)
+        remote_event = self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
+        msg = self.cumulus_message_adapter.load_nested_event(remote_event, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, remote_event, message_config)
 
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(bucket_name).delete()
-        self.assertEquals(result, out_msg)
-
+        self.assertEqual(result, out_msg)
 
     def test_non_object_configured_remote(self):
         """ test_non_object_configured_remote.input.json """
@@ -513,39 +529,43 @@ class Test(unittest.TestCase):
         bucket_name = in_msg['cma']['event']['replace']['Bucket']
         key_name = in_msg['cma']['event']['replace']['Key']
         data_filename = os.path.join(self.test_folder, key_name)
-        with open(data_filename, 'r') as f: datasource = json.load(f)
+        with open(data_filename, 'r') as file_data:
+            datasource = json.load(file_data)
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
 
-        remoteEvent = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, {})
-        msg = self.cumulus_message_adapter.loadNestedEvent(remoteEvent, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, remoteEvent, messageConfig)
+        remote_event = self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
+        msg = self.cumulus_message_adapter.load_nested_event(remote_event, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, remote_event, message_config)
 
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(bucket_name).delete()
-        self.assertEquals(result, out_msg)
+        self.assertEqual(result, out_msg)
 
-
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
     def test_sfn(self, getCurrentSfnTask_function):
         """ test sfn.input.json """
+        getCurrentSfnTask_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'sfn.input.json'))
         out = open(os.path.join(self.test_folder, 'sfn.output.json'))
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
     def test_context(self, getCurrentSfnTask_function):
         """ test storing context metadata """
+        getCurrentSfnTask_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'context.input.json'))
         out = open(os.path.join(self.test_folder, 'context.output.json'))
         ctx = open(os.path.join(self.context_folder, 'lambda-context.json'))
@@ -553,26 +573,28 @@ class Test(unittest.TestCase):
         out_msg = json.loads(out.read())
         context = json.loads(ctx.read())
 
-        rem = self.cumulus_message_adapter.loadAndUpdateRemoteEvent(in_msg, context)
-        msg = self.cumulus_message_adapter.loadNestedEvent(rem, context)
-        messageConfig = msg.get('messageConfig')
+        rem = self.cumulus_message_adapter.load_and_update_remote_event(in_msg, context)
+        msg = self.cumulus_message_adapter.load_nested_event(rem, context)
+        message_config = msg.get('messageConfig')
         if 'messageConfig' in msg:
             del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
     def test_inline_template(self, getCurrentSfnTask_function):
         """ test inline_template.input.json """
+        getCurrentSfnTask_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'inline_template.input.json'))
         out = open(os.path.join(self.test_folder, 'inline_template.output.json'))
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig');
-        if 'messageConfig' in msg: del msg['messageConfig'];
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
     def test_templates(self):
@@ -582,96 +604,95 @@ class Test(unittest.TestCase):
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask', return_value="Example")
+    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
     def test_cumulus_context(self, getCurrentSfnTask_function):
         """ test storing cumulus_context metadata """
+        getCurrentSfnTask_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'cumulus_context.input.json'))
         out = open(os.path.join(self.test_folder, 'cumulus_context.output.json'))
         in_msg = json.loads(inp.read())
         out_msg = json.loads(out.read())
 
-        msg = self.cumulus_message_adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        if 'messageConfig' in msg: del msg['messageConfig']
-        result = self.cumulus_message_adapter.createNextEvent(msg, in_msg, messageConfig)
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
     def test_input_jsonschema(self):
         """ test a working input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'input': 'input.json' }
+        schemas = {'input': 'input.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["payload"]= { "hello": "world" }
-        msg = adapter.loadNestedEvent(in_msg, {})
+        in_msg["payload"] = {"hello": "world"}
+        msg = adapter.load_nested_event(in_msg, {})
         assert msg["input"]["hello"] == "world"
 
     def test_failing_input_jsonschema(self):
         """ test a failing input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'input': 'input.json' }
+        schemas = {'input': 'input.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        in_msg["payload"]= { "hello": 1 }
+        in_msg["payload"] = {"hello": 1}
         try:
-            adapter.loadNestedEvent(in_msg, {})
+            adapter.load_nested_event(in_msg, {})
         except ValidationError as e:
             assert e.message == "input schema: 1 is not of type u'string'"
-            pass
 
     def test_config_jsonschema(self):
         """ test a working config schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'config': 'config.json' }
+        schemas = {'config': 'config.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        msg = adapter.loadNestedEvent(in_msg, {})
+        msg = adapter.load_nested_event(in_msg, {})
         assert msg["config"]["inlinestr"] == 'prefixbarsuffix'
 
     def test_failing_config_jsonschema(self):
         """ test a failing input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'config': 'config.json' }
+        schemas = {'config': 'config.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
         in_msg["task_config"]["boolean_option"] = '{$.meta.boolean_option}'
         in_msg["meta"]["boolean_option"] = "notgoingtowork"
         try:
-            adapter.loadNestedEvent(in_msg, {})
+            adapter.load_nested_event(in_msg, {})
         except ValidationError as e:
             assert e.message == "config schema: 'notgoingtowork' is not of type u'boolean'"
-            pass
 
     def test_output_jsonschema(self):
         """ test a working output schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'output': 'output.json' }
+        schemas = {'output': 'output.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        msg = adapter.loadNestedEvent(in_msg, {})
-        messageConfig = msg.get('messageConfig')
-        handler_response = { "goodbye": "world" }
-        result = adapter.createNextEvent(handler_response, in_msg, messageConfig)
+        msg = adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        handler_response = {"goodbye": "world"}
+        result = adapter.create_next_event(handler_response, in_msg, message_config)
         assert result["payload"]["goodbye"] == "world"
 
     def test_failing_output_jsonschema(self):
         """ test a working output schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
-        schemas = { 'output': 'output.json' }
+        schemas = {'output': 'output.json'}
         adapter = message_adapter.message_adapter(schemas)
         in_msg = json.loads(inp.read())
-        msg = adapter.loadNestedEvent(in_msg, {})
+        msg = adapter.load_nested_event(in_msg, {})
         messageConfig = msg.get('messageConfig')
-        handler_response = { "goodbye": 1 }
+        handler_response = {"goodbye": 1}
         try:
-            adapter.createNextEvent(handler_response, in_msg, messageConfig,)
+            adapter.create_next_event(handler_response, in_msg, messageConfig,)
         except ValidationError as e:
             assert e.message == "output schema: 1 is not of type u'string'"
-            pass
-

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -93,8 +93,8 @@ class Test(unittest.TestCase):
     # load_nested_event tests
     def test_returns_load_nested_event_local(self):
         """
-        Test returns 'config', 'input' and 'messageConfig' in expected format (workflow_config
-        backwards compatible)
+        Test returns 'config', 'input' and 'messageConfig' in expected format
+        (workflow_config backwards compatible)
         - 'input' in return value is from 'payload' in first argument object
         - 'config' in return value is the task ($.cumulus_meta.task) configuration
            with 'cumulus_message' excluded

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -32,7 +32,7 @@ class Test(unittest.TestCase):
     }
     event_without_replace = {'input': ':baby_whale:'}
     test_uuid = 'aad93279-95d4-4ada-8c43-aa5823f8bbbc'
-    next_event_object_key_name = "events/{0}".format(test_uuid)
+    next_event_object_key_name = f'events/{test_uuid}'
     s3 = aws.s3()
     cumulus_message_adapter = message_adapter.MessageAdapter()
     test_folder = os.path.join(os.getcwd(), 'examples/messages')

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -34,7 +34,7 @@ class Test(unittest.TestCase):
     test_uuid = 'aad93279-95d4-4ada-8c43-aa5823f8bbbc'
     next_event_object_key_name = "events/{0}".format(test_uuid)
     s3 = aws.s3()
-    cumulus_message_adapter = message_adapter.message_adapter()
+    cumulus_message_adapter = message_adapter.MessageAdapter()
     test_folder = os.path.join(os.getcwd(), 'examples/messages')
     context_folder = os.path.join(os.getcwd(), 'examples/contexts')
     schemas_folder = os.path.join(os.getcwd(), 'examples/schemas')
@@ -166,17 +166,17 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.load_nested_event(nested_event_local, {})
         assert result == nested_event_local_return
 
-    # assignOutputs tests
+    # assign_outputs tests
     def test_result_payload_without_config(self):
         """ Test nestedResponse is returned when no config argument is passed """
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
+        result = self.cumulus_message_adapter._MessageAdapter__assign_outputs(
             self.nested_response, {}, None)
         assert result['payload'] == self.nested_response
 
     def test_result_payload_without_config_outputs(self):
         """ Test nestedResponse is returned when config has no outputs key/value """
         message_config_without_outputs = {}
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
+        result = self.cumulus_message_adapter._MessageAdapter__assign_outputs(
             self.nested_response, {}, message_config_without_outputs)
         assert result['payload'] == self.nested_response
 
@@ -190,7 +190,7 @@ class Test(unittest.TestCase):
             }]
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
+        result = self.cumulus_message_adapter._MessageAdapter__assign_outputs(
             self.nested_response, {}, message_config_with_simple_outputs)
         assert result['payload'] == 's3://source.jpg'
 
@@ -206,7 +206,7 @@ class Test(unittest.TestCase):
             }]
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
+        result = self.cumulus_message_adapter._MessageAdapter__assign_outputs(
             self.nested_response, {}, message_config_with_nested_outputs)
         assert result['payload'] == {'dataLocation': 's3://source.jpg'}
 
@@ -228,7 +228,7 @@ class Test(unittest.TestCase):
             }
         }
 
-        result = self.cumulus_message_adapter._message_adapter__assignOutputs(
+        result = self.cumulus_message_adapter._MessageAdapter__assign_outputs(
             self.nested_response, event, message_config_with_nested_outputs)
         assert result['test'] == {
             'dataLocation': 's3://source.jpg',
@@ -425,7 +425,7 @@ class Test(unittest.TestCase):
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
 
-        remote_event= self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
+        remote_event = self.cumulus_message_adapter.load_and_update_remote_event(in_msg, {})
         msg = self.cumulus_message_adapter.load_nested_event(remote_event, {})
         message_config = msg.get('messageConfig')
         if 'messageConfig' in msg:
@@ -546,10 +546,10 @@ class Test(unittest.TestCase):
         self.s3.Bucket(bucket_name).delete()
         self.assertEqual(result, out_msg)
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
-    def test_sfn(self, getCurrentSfnTask_function):
+    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    def test_sfn(self, get_current_sfn_task_function):
         """ test sfn.input.json """
-        getCurrentSfnTask_function.return_value = "Example"
+        get_current_sfn_task_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'sfn.input.json'))
         out = open(os.path.join(self.test_folder, 'sfn.output.json'))
         in_msg = json.loads(inp.read())
@@ -562,10 +562,10 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
-    def test_context(self, getCurrentSfnTask_function):
+    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    def test_context(self, get_current_sfn_task_function):
         """ test storing context metadata """
-        getCurrentSfnTask_function.return_value = "Example"
+        get_current_sfn_task_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'context.input.json'))
         out = open(os.path.join(self.test_folder, 'context.output.json'))
         ctx = open(os.path.join(self.context_folder, 'lambda-context.json'))
@@ -581,10 +581,10 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
-    def test_inline_template(self, getCurrentSfnTask_function):
+    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    def test_inline_template(self, get_current_sfn_task_function):
         """ test inline_template.input.json """
-        getCurrentSfnTask_function.return_value = "Example"
+        get_current_sfn_task_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'inline_template.input.json'))
         out = open(os.path.join(self.test_folder, 'inline_template.output.json'))
         in_msg = json.loads(inp.read())
@@ -611,10 +611,10 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_message_adapter__getCurrentSfnTask')
-    def test_cumulus_context(self, getCurrentSfnTask_function):
+    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    def test_cumulus_context(self, get_current_sfn_task_function):
         """ test storing cumulus_context metadata """
-        getCurrentSfnTask_function.return_value = "Example"
+        get_current_sfn_task_function.return_value = "Example"
         inp = open(os.path.join(self.test_folder, 'cumulus_context.input.json'))
         out = open(os.path.join(self.test_folder, 'cumulus_context.output.json'))
         in_msg = json.loads(inp.read())
@@ -631,7 +631,7 @@ class Test(unittest.TestCase):
         """ test a working input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'input': 'input.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         in_msg["payload"] = {"hello": "world"}
         msg = adapter.load_nested_event(in_msg, {})
@@ -641,7 +641,7 @@ class Test(unittest.TestCase):
         """ test a failing input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'input': 'input.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         in_msg["payload"] = {"hello": 1}
         try:
@@ -653,7 +653,7 @@ class Test(unittest.TestCase):
         """ test a working config schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'config': 'config.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         msg = adapter.load_nested_event(in_msg, {})
         assert msg["config"]["inlinestr"] == 'prefixbarsuffix'
@@ -662,7 +662,7 @@ class Test(unittest.TestCase):
         """ test a failing input schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'config': 'config.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         in_msg["task_config"]["boolean_option"] = '{$.meta.boolean_option}'
         in_msg["meta"]["boolean_option"] = "notgoingtowork"
@@ -675,7 +675,7 @@ class Test(unittest.TestCase):
         """ test a working output schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'output': 'output.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         msg = adapter.load_nested_event(in_msg, {})
         message_config = msg.get('messageConfig')
@@ -687,7 +687,7 @@ class Test(unittest.TestCase):
         """ test a working output schema """
         inp = open(os.path.join(self.test_folder, 'templates.input.json'))
         schemas = {'output': 'output.json'}
-        adapter = message_adapter.message_adapter(schemas)
+        adapter = message_adapter.MessageAdapter(schemas)
         in_msg = json.loads(inp.read())
         msg = adapter.load_nested_event(in_msg, {})
         messageConfig = msg.get('messageConfig')

--- a/tests/test-program.py
+++ b/tests/test-program.py
@@ -59,7 +59,7 @@ class Test(unittest.TestCase):
         if context is None:
             context = {}
 
-        inp = open(os.path.join(self.test_folder, '{}.input.json'.format(testcase)))
+        inp = open(os.path.join(self.test_folder, f'{testcase}.input.json'))
         in_msg = json.loads(inp.read())
         s3meta = None
         if 'replace' in in_msg:
@@ -95,7 +95,7 @@ class Test(unittest.TestCase):
             create_next_event, json.dumps(all_input))
         assert exitstatus == 0
 
-        out = open(os.path.join(self.test_folder, '{}.output.json'.format(testcase)))
+        out = open(os.path.join(self.test_folder, f'{testcase}.output.json'))
         out_msg = json.loads(out.read())
         assert json.loads(next_event) == out_msg
 

--- a/tests/test-program.py
+++ b/tests/test-program.py
@@ -8,118 +8,128 @@ import unittest
 
 from message_adapter import aws
 
+
 class Test(unittest.TestCase):
+    # pylint: disable=attribute-defined-outside-init
+
     """ Test class """
     test_folder = os.path.join(os.getcwd(), 'examples/messages')
     os.environ["LAMBDA_TASK_ROOT"] = os.path.join(os.getcwd(), 'examples')
 
-    def placeRemoteMessage(self, in_msg):
+    def place_remote_message(self, in_msg):
         """
         Place the remote message on S3 before test
         """
-        self.s3 = aws.s3()
+        self.s3 = aws.s3()  # pylint: disable=invalid-name
         bucket_name = in_msg['replace']['Bucket']
         key_name = in_msg['replace']['Key']
         data_filename = os.path.join(self.test_folder, key_name)
-        with open(data_filename, 'r') as f: datasource = json.load(f)
+        with open(data_filename, 'r') as data_file:
+            datasource = json.load(data_file)
         self.s3.Bucket(bucket_name).create()
         self.s3.Object(bucket_name, key_name).put(Body=json.dumps(datasource))
-        return { 'bucket_name': bucket_name, 'key_name': key_name }
+        return {'bucket_name': bucket_name, 'key_name': key_name}
 
-    def cleanUpRemoteMessage(self, bucket_name, key_name):
+    def clean_up_remote_message(self, bucket_name, key_name):
+        """
+        cleans up the remote message from the s3 bucket
+        """
         delete_objects_object = {'Objects': [{'Key': key_name}]}
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(bucket_name).delete()
 
-    def executeCommand(self, cmd, inputMessage):
+    def execute_command(self, cmd, input_message):
         """
         execute an external command command, and returns command exit status, stdout and stderr
         """
         process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         outstr, errorstr = process.communicate(
-            input=inputMessage.encode())
+            input=input_message.encode())
         exitstatus = process.poll()
         if errorstr:
-            print (errorstr.decode()) # pylint: disable=superfluous-parens
+            print(errorstr.decode())  # pylint: disable=superfluous-parens
         return exitstatus, outstr.decode(), errorstr.decode()
 
-    def transformMessages(self, testcase, context={}): #pylint: disable=too-many-locals
+    def transform_messages(self, testcase, context=None):  # pylint: disable=too-many-locals
         """
         transform cumulus messages, and check if the command return status and outputs are correct.
         Each test case (such as 'basic') has its corresponding example messages and schemas.
         """
+        if context is None:
+            context = {}
+
         inp = open(os.path.join(self.test_folder, '{}.input.json'.format(testcase)))
         in_msg = json.loads(inp.read())
         s3meta = None
-        if ('replace' in in_msg):
-            s3meta = self.placeRemoteMessage(in_msg)
+        if 'replace' in in_msg:
+            s3meta = self.place_remote_message(in_msg)
         schemas = {
             'input': 'schemas/exmaples-messages.output.json',
             'output': 'schemas/exmaples-messages.output.json',
             'config': 'schemas/examples-messages.config.json'
         }
 
-        allInput = {'event': in_msg, 'context': context, 'schemas': schemas}
-        currentDirectory = os.getcwd()
-        remoteEventCmd = ['python', currentDirectory, 'loadAndUpdateRemoteEvent']
-        (exitstatus, remoteEvent, errorstr) = self.executeCommand( # pylint: disable=unused-variable
-            remoteEventCmd, json.dumps(allInput))
+        all_input = {'event': in_msg, 'context': context, 'schemas': schemas}
+        current_directory = os.getcwd()
+        remote_event_command = ['python', current_directory, 'loadAndUpdateRemoteEvent']
+        (exitstatus, remote_event, _) = self.execute_command(
+            remote_event_command, json.dumps(all_input))
         assert exitstatus == 0
-        fullEvent = json.loads(remoteEvent)
+        full_event = json.loads(remote_event)
 
-        allInput = {'event': fullEvent, 'context': context, 'schemas': schemas}
-        loadNestedEvent = ['python', currentDirectory, 'loadNestedEvent']
-        (exitstatus, nestedEvent, errorstr) = self.executeCommand( # pylint: disable=unused-variable
-            loadNestedEvent, json.dumps(allInput))
+        all_input = {'event': full_event, 'context': context, 'schemas': schemas}
+        load_nested_event = ['python', current_directory, 'loadNestedEvent']
+        (exitstatus, nested_event, _) = self.execute_command(
+            load_nested_event, json.dumps(all_input))
         assert exitstatus == 0
 
-        msg = json.loads(nestedEvent)
-        messageConfig = msg.get('messageConfig')
+        msg = json.loads(nested_event)
+        message_config = msg.get('messageConfig')
         if 'messageConfig' in msg:
             del msg['messageConfig']
-        allInput = {'handler_response': msg, 'event': fullEvent,
-                    'message_config': messageConfig, 'schemas': schemas}
-        createNextEvent = ['python', currentDirectory, 'createNextEvent']
-        (exitstatus, nextEvent, errorstr) = self.executeCommand(
-            createNextEvent, json.dumps(allInput))
+        all_input = {'handler_response': msg, 'event': full_event,
+                     'message_config': message_config, 'schemas': schemas}
+        create_next_event = ['python', current_directory, 'createNextEvent']
+        (exitstatus, next_event, _) = self.execute_command(
+            create_next_event, json.dumps(all_input))
         assert exitstatus == 0
 
         out = open(os.path.join(self.test_folder, '{}.output.json'.format(testcase)))
         out_msg = json.loads(out.read())
-        assert json.loads(nextEvent) == out_msg
+        assert json.loads(next_event) == out_msg
 
         if s3meta is not None:
-            self.cleanUpRemoteMessage(s3meta['bucket_name'], s3meta['key_name'])
+            self.clean_up_remote_message(s3meta['bucket_name'], s3meta['key_name'])
 
     def test_basic(self):
         """ test basic message """
-        self.transformMessages('basic')
+        self.transform_messages('basic')
 
     def test_exception(self):
         """ test remote message with exception """
-        self.transformMessages('exception')
+        self.transform_messages('exception')
 
     def test_jsonpath(self):
         """ test jsonpath message """
-        self.transformMessages('jsonpath')
+        self.transform_messages('jsonpath')
 
     def test_meta(self):
         """ test meta message """
-        self.transformMessages('meta')
+        self.transform_messages('meta')
 
     def test_remote(self):
         """ test remote message """
-        self.transformMessages('remote')
+        self.transform_messages('remote')
 
     def test_templates(self):
         """ test templates message """
-        self.transformMessages('templates')
+        self.transform_messages('templates')
 
     def test_validation_failure_case(self):
         """ test validation failure case """
         try:
-            self.transformMessages("invalidinput")
+            self.transform_messages("invalidinput")
         except AssertionError:
             return
         assert False


### PR DESCRIPTION
Resolves #56 

This PR updates cumulus-message-adapter to use/publish to python 3 only, and to build the cma binary package as python 3 compatible. 

Additionally minor style/variable naming/linting related changes were updated, string interpolation was changed to use f-strings,  and any python 2 import shims/logic were removed.     
