### PR TITLE
Cumulus 1486 refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             LOCALSTACK_HOST: localstack
           command: |
             . ~/venv36/bin/activate
-            pylint __main__.py -E
+            pylint_runner
             CUMULUS_ENV=testing nosetests -v -s
 
   build_python38:
@@ -91,7 +91,7 @@ jobs:
             LOCALSTACK_HOST: localstack
           command: |
             . ~/venv38/bin/activate
-            pylint __main__.py -E
+            pylint_runner
             CUMULUS_ENV=testing nosetests -v -s
 
   publish_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,8 @@ jobs:
       - run:
           name: Deploy to PyPi
           command: |
-            virtualenv ~/venv36
+            pip install --user virtualenv
+            ~/.local/bin/virtualenv ~/venv36
             . ~/venv36/bin/activate
             pip install twine
             python setup.py sdist

--- a/message_adapter/aws.py
+++ b/message_adapter/aws.py
@@ -99,7 +99,7 @@ def _get_task_name_from_execution_history(execution_history, arn):
         events_by_id[event['id']] = event
 
     for step in execution_history['events']:
-        # Find the ARN in thie history (the API is awful here).  When found, return its
+        # Find the ARN in the history (the API is awful here).  When found, return its
         # previousEventId's (TaskStateEntered) name
         lambda_of_type_and_matching_arn = (
             (step['type'] == 'LambdaFunctionScheduled' and

--- a/message_adapter/aws.py
+++ b/message_adapter/aws.py
@@ -35,6 +35,6 @@ def stepFn():
     if ('CUMULUS_ENV' in os.environ) and (os.environ["CUMULUS_ENV"] == 'testing'):
         return boto3.client(service_name='stepfunctions',
                             endpoint_url=localhost_s3_url(), region_name=region)
-    else:
-        config = Config(region_name=region, retries=dict(max_attempts=30))
-        return boto3.client('stepfunctions', config=config)
+
+    config = Config(region_name=region, retries=dict(max_attempts=30))
+    return boto3.client('stepfunctions', config=config)

--- a/message_adapter/aws.py
+++ b/message_adapter/aws.py
@@ -38,3 +38,80 @@ def stepFn():
 
     config = Config(region_name=region, retries=dict(max_attempts=30))
     return boto3.client('stepfunctions', config=config)
+
+
+def get_current_sfn_task(state_machine_arn, execution_name, arn):
+    """
+    * Given a state machine ARN, an execution name, and an optional Activity or Lambda ARN
+    * returns the most recent task name started for the given ARN in that execution,
+    * or if no ARN is supplied, the most recent task started.
+    *
+    * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+    * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+    * this if possible.
+    *
+    * @param {string} state_machine_arn The ARN of the state machine containing the execution
+    * @param {string} execution_name The name of the step function execution to look up
+    * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
+    * @returns {string} The name of the task being run
+    """
+    sfn = stepFn()
+    execution_arn = _get_sfn_execution_arn_by_name(state_machine_arn, execution_name)
+    execution_history = sfn.get_execution_history(
+        executionArn=execution_arn,
+        maxResults=40,
+        reverseOrder=True
+    )
+    return _get_task_name_from_execution_history(execution_history, arn)
+
+
+def _get_sfn_execution_arn_by_name(state_machine_arn, execution_name):
+    """
+    * Given a state machine arn and execution name, returns the execution's ARN
+    * @param {string} state_machine_arn The ARN of the state machine containing the execution
+    * @param {string} execution_name The name of the execution
+    * @returns {string} The execution's ARN
+    """
+    return (':').join([state_machine_arn.replace(':stateMachine:', ':execution:'),
+                       execution_name])
+
+
+def _get_task_name_from_execution_history(execution_history, arn):
+    """
+    * Given an execution history object returned by the StepFunctions API and an optional
+    * Activity or Lambda ARN returns the most recent task name started for the given ARN,
+    * or if no ARN is supplied, the most recent task started.
+    *
+    * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+    * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+    * this if possible.
+    *
+    * @param {dict} executionHistory The execution history returned by getExecutionHistory,
+    * assumed to be sorted so most recent executions come last
+    * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
+    * @throws If no matching task is found
+    * @returns {string} The matching task name
+    """
+    events_by_id = {}
+
+    # Create a lookup table for finding events by their id
+    for event in execution_history['events']:
+        events_by_id[event['id']] = event
+
+    for step in execution_history['events']:
+        # Find the ARN in thie history (the API is awful here).  When found, return its
+        # previousEventId's (TaskStateEntered) name
+        lambda_of_type_and_matching_arn = (
+            (step['type'] == 'LambdaFunctionScheduled' and
+             step['lambdaFunctionScheduledEventDetails']['resource'] == arn) or
+            (step['type'] == 'ActivityScheduled' and
+             step['activityScheduledEventDetails']['resource'] == arn))
+
+        if (arn is not None and lambda_of_type_and_matching_arn and
+                'stateEnteredEventDetails' in events_by_id[step['previousEventId']]):
+            return events_by_id[step['previousEventId']]['stateEnteredEventDetails']['name']
+
+        if step['type'] == 'TaskStateEntered':
+            return step['stateEnteredEventDetails']['name']
+
+    raise LookupError('No task found for ' + arn)

--- a/message_adapter/cumulus_message.py
+++ b/message_adapter/cumulus_message.py
@@ -1,6 +1,5 @@
 import json
 import re
-import sys
 import uuid
 
 from copy import deepcopy
@@ -158,6 +157,7 @@ def store_remote_response(incoming_event, default_max_size, config_keys):
     for key in config_keys:
         if event.get(key):
             del event[key]
+
     cumulus_meta = deepcopy(event['cumulus_meta'])
     replacement_data = replace_config_values['parsed_json_path'].find(event)
     if len(replacement_data) != 1:

--- a/message_adapter/cumulus_message.py
+++ b/message_adapter/cumulus_message.py
@@ -164,9 +164,7 @@ def store_remote_response(incoming_event, max_size, config_keys):
         raise Exception(f'JSON path invalid: {replace_config_values["parsed_json_path"]}')
     replacement_data = replacement_data[0]
 
-    estimated_data_size = len(json.dumps(replacement_data.value))
-    if sys.version_info.major > 3:
-        estimated_data_size = len(json.dumps(replacement_data.value).encode(('utf-8')))
+    estimated_data_size = len(json.dumps(replacement_data.value).encode(('utf-8')))
 
     if estimated_data_size < replace_config_values['max_size']:
         return event

--- a/message_adapter/cumulus_message.py
+++ b/message_adapter/cumulus_message.py
@@ -136,13 +136,13 @@ def resolve_config_templates(event, config):
     return _resolve_config_object(event, task_config)
 
 
-def store_remote_response(incoming_event, max_size, config_keys):
+def store_remote_response(incoming_event, default_max_size, config_keys):
     """
     * Stores part of a response message in S3 if it is too big to send to StepFunctions
-    * @param {*} incoming_event  - The response message
-    * @param {*} max_size        - The maximum size (in bytes) a response message portion
-    *                              can be before the method will store it in s3
-    * @param {*} config_keys     - A list of valid CMA configuration keys
+    * @param {*} incoming_event    - The response message
+    * @param {*} default_max_size  - The maximum size (in bytes) a response message portion
+    *                                can be before the method will store it in s3
+    * @param {*} config_keys       - A list of valid CMA configuration keys
     * @returns {*} A response message, possibly referencing an S3 object for its contents
     """
     event = deepcopy(incoming_event)
@@ -153,7 +153,7 @@ def store_remote_response(incoming_event, max_size, config_keys):
     if replace_config.get('FullMessage', False):
         replace_config['Path'] = '$'
 
-    replace_config_values = _parse_remote_config_from_event(replace_config, max_size)
+    replace_config_values = _parse_remote_config_from_event(replace_config, default_max_size)
 
     for key in config_keys:
         if event.get(key):
@@ -248,14 +248,14 @@ def _resolve_config_object(event, config):
     return config
 
 
-def _parse_remote_config_from_event(replace_config, max_size):
+def _parse_remote_config_from_event(replace_config, default_max_size):
     source_path = replace_config['Path']
     target_path = replace_config.get('TargetPath', replace_config['Path'])
-    max_size = replace_config.get('MaxSize', max_size)
+    default_max_size = replace_config.get('MaxSize', default_max_size)
     parsed_json_path = parse(source_path)
 
     return {
         'target_path': target_path,
-        'max_size': max_size,
+        'max_size': default_max_size,
         'parsed_json_path': parsed_json_path,
     }

--- a/message_adapter/cumulus_message.py
+++ b/message_adapter/cumulus_message.py
@@ -1,0 +1,263 @@
+import json
+import re
+import sys
+import uuid
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+from jsonpath_ng import parse
+from .aws import get_current_sfn_task, s3
+
+
+def load_config(event, context):
+    """
+    * Given a Cumulus message and context, returns the config object for the task
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} context The context object passed to AWS Lambda or containing an activityArn
+    * @returns {*} The task's configuration
+    """
+    if 'task_config' in event:
+        return event['task_config']
+    # Maintained for backwards compatibility
+    source = event['cumulus_meta']['message_source']
+    if source is None:
+        raise LookupError('cumulus_meta requires a message_source')
+    if source == 'local':
+        task_name = event['cumulus_meta']['task']
+    elif source == 'sfn':
+        task_name = _load_step_function_task_name(event, context)
+    else:
+        raise LookupError('Unknown event source: ' + source)
+    return _get_config(event, task_name) if task_name is not None else None
+
+
+def load_remote_event(event):
+    """
+    * Given a Cumulus message, checks for a 'replace' key and fetches a remote stored
+    * object from S3 and inserts it into the configured path
+    * @param {*} event An event in the Cumulus message format
+    * @returns {*} A Cumulus message with the remote message resolved
+    """
+
+    if 'replace' in event:
+        local_exception = event.get('exception', None)
+        _s3 = s3()
+        data = _s3.Object(event['replace']['Bucket'],
+                          event['replace']['Key']).get()
+        target_json_path = event['replace']['TargetPath']
+        parsed_json_path = parse(target_json_path)
+        if data is not None:
+            remote_event = json.loads(data['Body'].read().decode('utf-8'))
+            replacement_targets = parsed_json_path.find(event)
+            if not replacement_targets or len(replacement_targets) != 1:
+                raise Exception(f'Remote event configuration target {target_json_path} invalid')
+            try:
+                replacement_targets[0].value.update(remote_event)
+            except AttributeError:
+                parsed_json_path.update(event, remote_event)
+
+            event.pop('replace')
+            exception_bool = (local_exception and local_exception != 'None')
+            if exception_bool and (not event['exception'] or event['exception'] == 'None'):
+                event['exception'] = local_exception
+    return event
+
+
+# Config templating
+def resolve_path_str(event, json_path_string):
+    """
+    * Given a Cumulus message (AWS Lambda event) and a string containing a JSONPath
+    * template to interpret, returns the result of interpreting that template.
+    *
+    * Templating comes in three flavors:
+    *   1. Single curly-braces within a string ("some{$.path}value"). The JSONPaths
+    *      are replaced by the first value they match, coerced to string
+    *   2. A string surrounded by double curly-braces ("{{$.path}}").  The function
+    *      returns the first object matched by the JSONPath
+    *   3. A string surrounded by curly and square braces ("{[$.path]}"). The function
+    *      returns an array of all object matching the JSONPath
+    *
+    * It's likely we'll need some sort of bracket-escaping at some point down the line
+    *
+    * @param {*} event The Cumulus message
+    * @param {*} json_path_string A string containing a JSONPath template to resolve
+    * @returns {*} The resolved object
+    """
+    value_regex = r"^{[^\[\]].*}$"
+    array_regex = r"^{\[.*\]}$"
+    template_regex = '{[^}]+}'
+
+    if re.search(value_regex, json_path_string):
+        match_data = parse(json_path_string.lstrip('{').rstrip('}')).find(event)
+        return match_data[0].value if match_data else None
+
+    if re.search(array_regex, json_path_string):
+        parsed_json_path = json_path_string.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
+        match_data = parse(parsed_json_path).find(event)
+        return [item.value for item in match_data] if match_data else []
+
+    if re.search(template_regex, json_path_string):
+        matches = re.findall(template_regex, json_path_string)
+        for match in matches:
+            match_data = parse(match.lstrip('{').rstrip('}')).find(event)
+            if match_data:
+                json_path_string = json_path_string.replace(match, match_data[0].value)
+        return json_path_string
+
+    return json_path_string
+
+
+def resolve_input(event, config):
+    """
+    * Given a Cumulus message and its config, returns the input object to send to the
+    * task, as defined under config.cumulus_message
+    * @param {*} event The Cumulus message
+    * @param {*} config The config object
+    * @returns {*} The object to place on the input key of the task's event
+    """
+    if ('cumulus_message' in config and 'input' in config['cumulus_message']):
+        input_path = config['cumulus_message']['input']
+        return resolve_path_str(event, input_path)
+    return event.get('payload')
+
+
+def resolve_config_templates(event, config):
+    """
+    * Given a config object containing possible JSONPath-templated values, resolves
+    * all the values in the object using JSONPaths into the provided event.
+    *
+    * @param {*} event The event that paths resolve against
+    * @param {*} config A config object, containing paths
+    * @returns {*} A config object with all JSONPaths resolved
+    """
+    task_config = config.copy()
+    if 'cumulus_message' in task_config:
+        del task_config['cumulus_message']
+    return _resolve_config_object(event, task_config)
+
+
+def store_remote_response(incoming_event, max_size, config_keys):
+    """
+    * Stores part of a response message in S3 if it is too big to send to StepFunctions
+    * @param {*} incoming_event  - The response message
+    * @param {*} max_size        - The maximum size (in bytes) a response message portion
+    *                              can be before the method will store it in s3
+    * @param {*} config_keys     - A list of valid CMA configuration keys
+    * @returns {*} A response message, possibly referencing an S3 object for its contents
+    """
+    event = deepcopy(incoming_event)
+    replace_config = event.get('ReplaceConfig', None)
+    if not replace_config:
+        return event
+    # Set default value if FullMessage flag set
+    if replace_config.get('FullMessage', False):
+        replace_config['Path'] = '$'
+
+    replace_config_values = _parse_remote_config_from_event(replace_config, max_size)
+
+    for key in config_keys:
+        if event.get(key):
+            del event[key]
+    cumulus_meta = deepcopy(event['cumulus_meta'])
+    replacement_data = replace_config_values['parsed_json_path'].find(event)
+    if len(replacement_data) != 1:
+        raise Exception(f'JSON path invalid: {replace_config_values["parsed_json_path"]}')
+    replacement_data = replacement_data[0]
+
+    estimated_data_size = len(json.dumps(replacement_data.value))
+    if sys.version_info.major > 3:
+        estimated_data_size = len(json.dumps(replacement_data.value).encode(('utf-8')))
+
+    if estimated_data_size < replace_config_values['max_size']:
+        return event
+
+    _s3 = s3()
+    s3_bucket = event['cumulus_meta']['system_bucket']
+    s3_key = ('/').join(['events', str(uuid.uuid4())])
+    s3_params = {
+        'Expires': datetime.utcnow() + timedelta(days=7),  # Expire in a week
+        'Body': json.dumps(replacement_data.value)
+    }
+    _s3.Object(s3_bucket, s3_key).put(**s3_params)
+
+    try:
+        replacement_data.value.clear()
+    except AttributeError:
+        replace_config_values['parsed_json_path'].update(event, '')
+
+    remote_configuration = {'Bucket': s3_bucket, 'Key': s3_key,
+                            'TargetPath': replace_config_values['target_path']}
+    event['cumulus_meta'] = event.get('cumulus_meta', cumulus_meta)
+    event['replace'] = remote_configuration
+    return event
+
+
+def _load_step_function_task_name(event, context):
+    """
+    * For StepFunctions, returns the configuration corresponding to the current execution
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} context The context object passed to AWS Lambda or containing an activityArn
+    * @returns {*} The task's configuration
+    """
+    meta = event['cumulus_meta']
+    if 'invokedFunctionArn' in context:
+        arn = context['invokedFunctionArn']
+    else:
+        arn = context.get('invoked_function_arn', context.get('activityArn'))
+    return get_current_sfn_task(meta['state_machine'], meta['execution_name'], arn)
+
+
+def _get_config(event, task_name):
+    """
+    * Returns the configuration for the task with the given name, or an empty object if no
+    * such task is configured.
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} task_name The name of the Cumulus task
+    * @returns {*} The configuration object
+    """
+    config = {}
+    if ('workflow_config' in event and task_name in event['workflow_config']):
+        config = event['workflow_config'][task_name]
+    return config
+
+
+def _resolve_config_object(event, config):
+    """
+    * Recursive helper for resolve_config_templates
+    *
+    * Given a config object containing possible JSONPath-templated values, resolves
+    * all the values in the object using JSONPaths into the provided event.
+    *
+    * @param {*} event The event that paths resolve against
+    * @param {*} config A config object, containing paths
+    * @returns {*} A config object with all JSONPaths resolved
+    """
+
+    if isinstance(config, str):
+        return resolve_path_str(event, config)
+
+    if isinstance(config, list):
+        for i in range(0, len(config)):  # pylint: disable=consider-using-enumerate
+            config[i] = _resolve_config_object(event, config[i])
+        return config
+
+    if (config is not None and isinstance(config, dict)):
+        result = {}
+        for key in config.keys():
+            result[key] = _resolve_config_object(event, config[key])
+        return result
+
+    return config
+
+
+def _parse_remote_config_from_event(replace_config, max_size):
+    source_path = replace_config['Path']
+    target_path = replace_config.get('TargetPath', replace_config['Path'])
+    max_size = replace_config.get('MaxSize', max_size)
+    parsed_json_path = parse(source_path)
+
+    return {
+        'target_path': target_path,
+        'max_size': max_size,
+        'parsed_json_path': parsed_json_path,
+    }

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -11,6 +11,298 @@ from jsonschema import validate
 from .aws import stepFn, s3
 
 
+def _assign_json_path_value(message, jspath, value):
+    """
+    * Assign (update or insert) a value to message based on jsonpath.
+    * Create the keys if jspath doesn't already exist in the message. In this case, we
+    * support 'simple' jsonpath like $.path1.path2.path3....
+    * @param {*} message The message to be update
+    * @return {*} updated message
+    """
+    if not parse(jspath).find(message):
+        paths = jspath.lstrip('$.').split('.')
+        current_item = message
+        key_not_found = False
+        for path in paths:
+            if key_not_found or path not in current_item:
+                key_not_found = True
+                new_path_dict = {}
+                # Add missing key to existing dict
+                current_item[path] = new_path_dict
+                # Set current item to newly created dict
+                current_item = new_path_dict
+            else:
+                current_item = current_item[path]
+    parse(jspath).update(message, value)
+    return message
+
+
+def _resolve_config_object(event, config):
+    """
+    * Recursive helper for resolveConfigTemplates
+    *
+    * Given a config object containing possible JSONPath-templated values, resolves
+    * all the values in the object using JSONPaths into the provided event.
+    *
+    * @param {*} event The event that paths resolve against
+    * @param {*} config A config object, containing paths
+    * @returns {*} A config object with all JSONPaths resolved
+    """
+
+    if isinstance(config, str):
+        return _resolve_path_str(event, config)
+
+    if isinstance(config, list):
+        for i in range(0, len(config)):  # pylint: disable=consider-using-enumerate
+            config[i] = _resolve_config_object(event, config[i])
+        return config
+
+    if (config is not None and isinstance(config, dict)):
+        result = {}
+        for key in config.keys():
+            result[key] = _resolve_config_object(event, config[key])
+        return result
+
+    return config
+
+
+def _resolve_config_templates(event, config):
+    """
+    * Given a config object containing possible JSONPath-templated values, resolves
+    * all the values in the object using JSONPaths into the provided event.
+    *
+    * @param {*} event The event that paths resolve against
+    * @param {*} config A config object, containing paths
+    * @returns {*} A config object with all JSONPaths resolved
+    """
+    task_config = config.copy()
+    if 'cumulus_message' in task_config:
+        del task_config['cumulus_message']
+    return _resolve_config_object(event, task_config)
+
+
+# Payload determination
+def _resolve_input(event, config):
+    """
+    * Given a Cumulus message and its config, returns the input object to send to the
+    * task, as defined under config.cumulus_message
+    * @param {*} event The Cumulus message
+    * @param {*} config The config object
+    * @returns {*} The object to place on the input key of the task's event
+    """
+    if ('cumulus_message' in config and 'input' in config['cumulus_message']):
+        input_path = config['cumulus_message']['input']
+        return _resolve_path_str(event, input_path)
+    return event.get('payload')
+
+
+# Config templating
+def _resolve_path_str(event, json_path_string):
+    """
+    * Given a Cumulus message (AWS Lambda event) and a string containing a JSONPath
+    * template to interpret, returns the result of interpreting that template.
+    *
+    * Templating comes in three flavors:
+    *   1. Single curly-braces within a string ("some{$.path}value"). The JSONPaths
+    *      are replaced by the first value they match, coerced to string
+    *   2. A string surrounded by double curly-braces ("{{$.path}}").  The function
+    *      returns the first object matched by the JSONPath
+    *   3. A string surrounded by curly and square braces ("{[$.path]}"). The function
+    *      returns an array of all object matching the JSONPath
+    *
+    * It's likely we'll need some sort of bracket-escaping at some point down the line
+    *
+    * @param {*} event The Cumulus message
+    * @param {*} json_path_string A string containing a JSONPath template to resolve
+    * @returns {*} The resolved object
+    """
+    value_regex = r"^{[^\[\]].*}$"
+    array_regex = r"^{\[.*\]}$"
+    template_regex = '{[^}]+}'
+
+    if re.search(value_regex, json_path_string):
+        match_data = parse(json_path_string.lstrip('{').rstrip('}')).find(event)
+        return match_data[0].value if match_data else None
+
+    if re.search(array_regex, json_path_string):
+        parsed_json_path = json_path_string.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
+        match_data = parse(parsed_json_path).find(event)
+        return [item.value for item in match_data] if match_data else []
+
+    if re.search(template_regex, json_path_string):
+        matches = re.findall(template_regex, json_path_string)
+        for match in matches:
+            match_data = parse(match.lstrip('{').rstrip('}')).find(event)
+            if match_data:
+                json_path_string = json_path_string.replace(match, match_data[0].value)
+        return json_path_string
+
+    return json_path_string
+
+
+# Loading task configuration from workload template
+def _load_step_function_task_name(event, context):
+    """
+    * For StepFunctions, returns the configuration corresponding to the current execution
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} context The context object passed to AWS Lambda or containing an activityArn
+    * @returns {*} The task's configuration
+    """
+    meta = event['cumulus_meta']
+    if 'invokedFunctionArn' in context:
+        arn = context['invokedFunctionArn']
+    else:
+        arn = context.get('invoked_function_arn', context.get('activityArn'))
+    return _get_current_sfn_task(meta['state_machine'], meta['execution_name'], arn)
+
+
+def _load_remote_event(event):
+    if 'replace' in event:
+        local_exception = event.get('exception', None)
+        _s3 = s3()
+        data = _s3.Object(event['replace']['Bucket'],
+                          event['replace']['Key']).get()
+        target_json_path = event['replace']['TargetPath']
+        parsed_json_path = parse(target_json_path)
+        if data is not None:
+            remote_event = json.loads(data['Body'].read().decode('utf-8'))
+            replacement_targets = parsed_json_path.find(event)
+            if not replacement_targets or len(replacement_targets) != 1:
+                raise Exception(f'Remote event configuration target {target_json_path} invalid')
+            try:
+                replacement_targets[0].value.update(remote_event)
+            except AttributeError:
+                parsed_json_path.update(event, remote_event)
+
+            event.pop('replace')
+            exception_bool = (local_exception and local_exception != 'None')
+            if exception_bool and (not event['exception'] or event['exception'] == 'None'):
+                event['exception'] = local_exception
+    return event
+
+
+def _get_sfn_execution_arn_by_name(state_machine_arn, execution_name):
+    """
+    * Given a state machine arn and execution name, returns the execution's ARN
+    * @param {string} state_machine_arn The ARN of the state machine containing the execution
+    * @param {string} execution_name The name of the execution
+    * @returns {string} The execution's ARN
+    """
+    return (':').join([state_machine_arn.replace(':stateMachine:', ':execution:'),
+                       execution_name])
+
+
+def _get_task_name_from_execution_history(execution_history, arn):
+    """
+    * Given an execution history object returned by the StepFunctions API and an optional
+    * Activity or Lambda ARN returns the most recent task name started for the given ARN,
+    * or if no ARN is supplied, the most recent task started.
+    *
+    * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+    * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+    * this if possible.
+    *
+    * @param {dict} executionHistory The execution history returned by getExecutionHistory,
+    * assumed to be sorted so most recent executions come last
+    * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
+    * @throws If no matching task is found
+    * @returns {string} The matching task name
+    """
+    events_by_id = {}
+
+    # Create a lookup table for finding events by their id
+    for event in execution_history['events']:
+        events_by_id[event['id']] = event
+
+    for step in execution_history['events']:
+        # Find the ARN in thie history (the API is awful here).  When found, return its
+        # previousEventId's (TaskStateEntered) name
+        lambda_of_type_and_matching_arn = (
+            (step['type'] == 'LambdaFunctionScheduled' and
+             step['lambdaFunctionScheduledEventDetails']['resource'] == arn) or
+            (step['type'] == 'ActivityScheduled' and
+             step['activityScheduledEventDetails']['resource'] == arn))
+
+        if (arn is not None and lambda_of_type_and_matching_arn and
+                'stateEnteredEventDetails' in events_by_id[step['previousEventId']]):
+            return events_by_id[step['previousEventId']]['stateEnteredEventDetails']['name']
+
+        if step['type'] == 'TaskStateEntered':
+            return step['stateEnteredEventDetails']['name']
+
+    raise LookupError('No task found for ' + arn)
+
+
+def _get_current_sfn_task(state_machine_arn, execution_name, arn):
+    """
+    * Given a state machine ARN, an execution name, and an optional Activity or Lambda ARN
+    * returns the most recent task name started for the given ARN in that execution,
+    * or if no ARN is supplied, the most recent task started.
+    *
+    * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
+    * execution is the desired execution. This WILL BREAK parallel executions, so always supply
+    * this if possible.
+    *
+    * @param {string} state_machine_arn The ARN of the state machine containing the execution
+    * @param {string} execution_name The name of the step function execution to look up
+    * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
+    * @returns {string} The name of the task being run
+    """
+    sfn = stepFn()
+    execution_arn = _get_sfn_execution_arn_by_name(state_machine_arn, execution_name)
+    execution_history = sfn.get_execution_history(
+        executionArn=execution_arn,
+        maxResults=40,
+        reverseOrder=True
+    )
+    return _get_task_name_from_execution_history(execution_history, arn)
+
+
+def _parse_parameter_configuration(event):
+    parsed_event = event
+    if event.get('cma'):
+        updated_event = {k: v for (k, v) in event['cma'].items() if k != 'event'}
+        parsed_event = event['cma']['event']
+        parsed_event.update(updated_event)
+    return parsed_event
+
+
+def _get_config(event, task_name):
+    """
+    * Returns the configuration for the task with the given name, or an empty object if no
+    * such task is configured.
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} task_name The name of the Cumulus task
+    * @returns {*} The configuration object
+    """
+    config = {}
+    if ('workflow_config' in event and task_name in event['workflow_config']):
+        config = event['workflow_config'][task_name]
+    return config
+
+
+def _load_config(event, context):
+    """
+    * Given a Cumulus message and context, returns the config object for the task
+    * @param {*} event An event in the Cumulus message format with remote parts resolved
+    * @param {*} context The context object passed to AWS Lambda or containing an activityArn
+    * @returns {*} The task's configuration
+    """
+    if 'task_config' in event:
+        return event['task_config']
+    # Maintained for backwards compatibility
+    source = event['cumulus_meta']['message_source']
+    if source is None:
+        raise LookupError('cumulus_meta requires a message_source')
+    if source == 'local':
+        task_name = event['cumulus_meta']['task']
+    elif source == 'sfn':
+        task_name = _load_step_function_task_name(event, context)
+    else:
+        raise LookupError('Unknown event source: ' + source)
+    return _get_config(event, task_name) if task_name is not None else None
+
+
 class MessageAdapter:
     """
     transforms the cumulus message
@@ -21,113 +313,12 @@ class MessageAdapter:
     def __init__(self, schemas=None):
         self.schemas = schemas
 
-    def __get_sfn_execution_arn_by_name(self, state_machine_arn, execution_name):
-        """
-        * Given a state machine arn and execution name, returns the execution's ARN
-        * @param {string} state_machine_arn The ARN of the state machine containing the execution
-        * @param {string} execution_name The name of the execution
-        * @returns {string} The execution's ARN
-        """
-        return (':').join([state_machine_arn.replace(':stateMachine:', ':execution:'),
-                           execution_name])
-
-    def __get_task_name_from_execution_history(self, execution_history, arn):
-        """
-        * Given an execution history object returned by the StepFunctions API and an optional
-        * Activity or Lambda ARN returns the most recent task name started for the given ARN,
-        * or if no ARN is supplied, the most recent task started.
-        *
-        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
-        * execution is the desired execution. This WILL BREAK parallel executions, so always supply
-        * this if possible.
-        *
-        * @param {dict} executionHistory The execution history returned by getExecutionHistory,
-        * assumed to be sorted so most recent executions come last
-        * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
-        * @throws If no matching task is found
-        * @returns {string} The matching task name
-        """
-        events_by_id = {}
-
-        # Create a lookup table for finding events by their id
-        for event in execution_history['events']:
-            events_by_id[event['id']] = event
-
-        for step in execution_history['events']:
-            # Find the ARN in thie history (the API is awful here).  When found, return its
-            # previousEventId's (TaskStateEntered) name
-            if (arn is not None and
-                    ((step['type'] == 'LambdaFunctionScheduled' and
-                      step['lambdaFunctionScheduledEventDetails']['resource'] == arn) or
-                     (step['type'] == 'ActivityScheduled' and
-                      step['activityScheduledEventDetails']['resource'] == arn)) and
-                    'stateEnteredEventDetails' in events_by_id[step['previousEventId']]):
-                return events_by_id[step['previousEventId']]['stateEnteredEventDetails']['name']
-            elif step['type'] == 'TaskStateEntered':
-                return step['stateEnteredEventDetails']['name']
-        raise LookupError('No task found for ' + arn)
-
-    def __get_current_sfn_task(self, state_machine_arn, execution_name, arn):
-        """
-        * Given a state machine ARN, an execution name, and an optional Activity or Lambda ARN
-        * returns the most recent task name started for the given ARN in that execution,
-        * or if no ARN is supplied, the most recent task started.
-        *
-        * IMPORTANT! If no ARN is supplied, this message assumes that the most recently started
-        * execution is the desired execution. This WILL BREAK parallel executions, so always supply
-        * this if possible.
-        *
-        * @param {string} state_machine_arn The ARN of the state machine containing the execution
-        * @param {string} execution_name The name of the step function execution to look up
-        * @param {string} arn An ARN to an Activity or Lambda to find. See "IMPORTANT!"
-        * @returns {string} The name of the task being run
-        """
-        sfn = stepFn()
-        execution_arn = self.__get_sfn_execution_arn_by_name(state_machine_arn, execution_name)
-        execution_history = sfn.get_execution_history(
-            executionArn=execution_arn,
-            maxResults=40,
-            reverseOrder=True
-        )
-        return self.__get_task_name_from_execution_history(execution_history, arn)
-
     ##################################
     #  Input message interpretation  #
     ##################################
 
-    def __parse_parameter_configuration(self, event):
-        parsed_event = event
-        if event.get('cma'):
-            updated_event = {k: v for (k, v) in event['cma'].items() if k != 'event'}
-            parsed_event = event['cma']['event']
-            parsed_event.update(updated_event)
-        return parsed_event
-
-    def __load_remote_event(self, event):
-        if 'replace' in event:
-            local_exception = event.get('exception', None)
-            _s3 = s3()
-            data = _s3.Object(event['replace']['Bucket'],
-                              event['replace']['Key']).get()
-            target_json_path = event['replace']['TargetPath']
-            parsed_json_path = parse(target_json_path)
-            if data is not None:
-                remote_event = json.loads(data['Body'].read().decode('utf-8'))
-                replacement_targets = parsed_json_path.find(event)
-                if not replacement_targets or len(replacement_targets) != 1:
-                    raise Exception(f'Remote event configuration target {target_json_path} invalid')
-                try:
-                    replacement_targets[0].value.update(remote_event)
-                except AttributeError:
-                    parsed_json_path.update(event, remote_event)
-
-                event.pop('replace')
-                exception_bool = (local_exception and local_exception != 'None')
-                if exception_bool and (not event['exception'] or event['exception'] == 'None'):
-                    event['exception'] = local_exception
-        return event
-
-    def load_and_update_remote_event(self, incoming_event, context):
+    @staticmethod
+    def load_and_update_remote_event(incoming_event, context):
         """
         * Looks at a Cumulus message. If the message has part of its data stored remotely in
         * S3, fetches that data, otherwise it returns the full message, both cases updated with
@@ -141,11 +332,11 @@ class MessageAdapter:
 
         if incoming_event.get('cma'):
             cma_event = deepcopy(incoming_event)
-            event = self.__load_remote_event(event['cma'].get('event'))
+            event = _load_remote_event(event['cma'].get('event'))
             cma_event['cma']['event'].update(event)
-            event = self.__parse_parameter_configuration(cma_event)
+            event = _parse_parameter_configuration(cma_event)
         else:
-            event = self.__load_remote_event(event)
+            event = _load_remote_event(event)
 
         if context and 'meta' in event and 'workflow_tasks' in event['meta']:
             cumulus_meta = event['cumulus_meta']
@@ -155,61 +346,11 @@ class MessageAdapter:
             task_meta['arn'] = context.get('invoked_function_arn',
                                            context.get('invokedFunctionArn',
                                                        context.get('activityArn')))
-            task_name = self.__get_current_sfn_task(cumulus_meta['state_machine'],
-                                                    cumulus_meta['execution_name'],
-                                                    task_meta['arn'])
+            task_name = _get_current_sfn_task(cumulus_meta['state_machine'],
+                                              cumulus_meta['execution_name'],
+                                              task_meta['arn'])
             event['meta']['workflow_tasks'][task_name] = task_meta
         return event
-
-    # Loading task configuration from workload template
-
-    def __get_config(self, event, task_name):
-        """
-        * Returns the configuration for the task with the given name, or an empty object if no
-        * such task is configured.
-        * @param {*} event An event in the Cumulus message format with remote parts resolved
-        * @param {*} task_name The name of the Cumulus task
-        * @returns {*} The configuration object
-        """
-        config = {}
-        if ('workflow_config' in event and task_name in event['workflow_config']):
-            config = event['workflow_config'][task_name]
-        return config
-
-    def __load_step_function_task_name(self, event, context):
-        """
-        * For StepFunctions, returns the configuration corresponding to the current execution
-        * @param {*} event An event in the Cumulus message format with remote parts resolved
-        * @param {*} context The context object passed to AWS Lambda or containing an activityArn
-        * @returns {*} The task's configuration
-        """
-        meta = event['cumulus_meta']
-        if 'invokedFunctionArn' in context:
-            arn = context['invokedFunctionArn']
-        else:
-            arn = context.get('invoked_function_arn', context.get('activityArn'))
-        return self.__get_current_sfn_task(meta['state_machine'], meta['execution_name'], arn)
-
-    def __load_config(self, event, context):
-        """
-        * Given a Cumulus message and context, returns the config object for the task
-        * @param {*} event An event in the Cumulus message format with remote parts resolved
-        * @param {*} context The context object passed to AWS Lambda or containing an activityArn
-        * @returns {*} The task's configuration
-        """
-        if 'task_config' in event:
-            return event['task_config']
-        # Maintained for backwards compatibility
-        source = event['cumulus_meta']['message_source']
-        if source is None:
-            raise LookupError('cumulus_meta requires a message_source')
-        elif source == 'local':
-            task_name = event['cumulus_meta']['task']
-        elif source == 'sfn':
-            task_name = self.__load_step_function_task_name(event, context)
-        else:
-            raise LookupError('Unknown event source: ' + source)
-        return self.__get_config(event, task_name) if task_name is not None else None
 
     def __get_jsonschema(self, schema_type):
         schemas = self.schemas
@@ -232,105 +373,6 @@ class MessageAdapter:
                 exception.message = f'{schema_type} schema: {str(exception)}'
                 raise exception
 
-    # Config templating
-    def __resolve_path_str(self, event, json_path_string):
-        """
-        * Given a Cumulus message (AWS Lambda event) and a string containing a JSONPath
-        * template to interpret, returns the result of interpreting that template.
-        *
-        * Templating comes in three flavors:
-        *   1. Single curly-braces within a string ("some{$.path}value"). The JSONPaths
-        *      are replaced by the first value they match, coerced to string
-        *   2. A string surrounded by double curly-braces ("{{$.path}}").  The function
-        *      returns the first object matched by the JSONPath
-        *   3. A string surrounded by curly and square braces ("{[$.path]}"). The function
-        *      returns an array of all object matching the JSONPath
-        *
-        * It's likely we'll need some sort of bracket-escaping at some point down the line
-        *
-        * @param {*} event The Cumulus message
-        * @param {*} json_path_string A string containing a JSONPath template to resolve
-        * @returns {*} The resolved object
-        """
-        value_regex = r"^{[^\[\]].*}$"
-        array_regex = r"^{\[.*\]}$"
-        template_regex = '{[^}]+}'
-
-        if re.search(value_regex, json_path_string):
-            match_data = parse(json_path_string.lstrip('{').rstrip('}')).find(event)
-            return match_data[0].value if match_data else None
-
-        elif re.search(array_regex, json_path_string):
-            parsed_json_path = json_path_string.lstrip('{').rstrip('}').lstrip('[').rstrip(']')
-            match_data = parse(parsed_json_path).find(event)
-            return [item.value for item in match_data] if match_data else []
-
-        elif re.search(template_regex, json_path_string):
-            matches = re.findall(template_regex, json_path_string)
-            for match in matches:
-                match_data = parse(match.lstrip('{').rstrip('}')).find(event)
-                if match_data:
-                    json_path_string = json_path_string.replace(match, match_data[0].value)
-            return json_path_string
-
-        return json_path_string
-
-    def __resolve_config_object(self, event, config):
-        """
-        * Recursive helper for resolveConfigTemplates
-        *
-        * Given a config object containing possible JSONPath-templated values, resolves
-        * all the values in the object using JSONPaths into the provided event.
-        *
-        * @param {*} event The event that paths resolve against
-        * @param {*} config A config object, containing paths
-        * @returns {*} A config object with all JSONPaths resolved
-        """
-
-        if isinstance(config, str):
-            return self.__resolve_path_str(event, config)
-
-        if isinstance(config, list):
-            for i in range(0, len(config)):  # pylint: disable=consider-using-enumerate
-                config[i] = self.__resolve_config_object(event, config[i])
-            return config
-
-        elif (config is not None and isinstance(config, dict)):
-            result = {}
-            for key in config.keys():
-                result[key] = self.__resolve_config_object(event, config[key])
-            return result
-
-        return config
-
-    def __resolve_config_templates(self, event, config):
-        """
-        * Given a config object containing possible JSONPath-templated values, resolves
-        * all the values in the object using JSONPaths into the provided event.
-        *
-        * @param {*} event The event that paths resolve against
-        * @param {*} config A config object, containing paths
-        * @returns {*} A config object with all JSONPaths resolved
-        """
-        task_config = config.copy()
-        if 'cumulus_message' in task_config:
-            del task_config['cumulus_message']
-        return self.__resolve_config_object(event, task_config)
-
-    # Payload determination
-    def __resolve_input(self, event, config):
-        """
-        * Given a Cumulus message and its config, returns the input object to send to the
-        * task, as defined under config.cumulus_message
-        * @param {*} event The Cumulus message
-        * @param {*} config The config object
-        * @returns {*} The object to place on the input key of the task's event
-        """
-        if ('cumulus_message' in config and 'input' in config['cumulus_message']):
-            input_path = config['cumulus_message']['input']
-            return self.__resolve_path_str(event, input_path)
-        return event.get('payload')
-
     def load_nested_event(self, event, context):
         """
         * Interprets an incoming event as a Cumulus workflow message
@@ -338,9 +380,9 @@ class MessageAdapter:
         * @param {*} event The input message sent to the Lambda
         * @returns {*} message that is ready to pass to an inner task
         """
-        config = self.__load_config(event, context)
-        final_config = self.__resolve_config_templates(event, config)
-        final_payload = self.__resolve_input(event, config)
+        config = _load_config(event, context)
+        final_config = _resolve_config_templates(event, config)
+        final_payload = _resolve_input(event, config)
         response = {'input': final_payload}
         self.__validate_json(final_payload, 'input')
         self.__validate_json(final_config, 'config')
@@ -371,33 +413,8 @@ class MessageAdapter:
     #############################
     # Output message creation   #
     #############################
-
-    def __assign_json_path_value(self, message, jspath, value):
-        """
-        * Assign (update or insert) a value to message based on jsonpath.
-        * Create the keys if jspath doesn't already exist in the message. In this case, we
-        * support 'simple' jsonpath like $.path1.path2.path3....
-        * @param {*} message The message to be update
-        * @return {*} updated message
-        """
-        if not parse(jspath).find(message):
-            paths = jspath.lstrip('$.').split('.')
-            current_item = message
-            key_not_found = False
-            for path in paths:
-                if key_not_found or path not in current_item:
-                    key_not_found = True
-                    new_path_dict = {}
-                    # Add missing key to existing dict
-                    current_item[path] = new_path_dict
-                    # Set current item to newly created dict
-                    current_item = new_path_dict
-                else:
-                    current_item = current_item[path]
-        parse(jspath).update(message, value)
-        return message
-
-    def __assign_outputs(self, handler_response, event, message_config):
+    @staticmethod
+    def __assign_outputs(handler_response, event, message_config):
         """
         * Applies a task's return value to an output message as defined in config.cumulus_message
         *
@@ -414,12 +431,24 @@ class MessageAdapter:
                 source_path = output['source']
                 dest_path = output['destination']
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
-                value = self.__resolve_path_str(handler_response, source_path)
-                self.__assign_json_path_value(result, dest_json_path, value)
+                value = _resolve_path_str(handler_response, source_path)
+                _assign_json_path_value(result, dest_json_path, value)
         else:
             result['payload'] = handler_response
 
         return result
+
+    def __parse_remote_config_from_event(self, replace_config):
+        source_path = replace_config['Path']
+        target_path = replace_config.get('TargetPath', replace_config['Path'])
+        max_size = replace_config.get('MaxSize', self.REMOTE_DEFAULT_MAX_SIZE)
+        parsed_json_path = parse(source_path)
+
+        return {
+            'target_path': target_path,
+            'max_size': max_size,
+            'parsed_json_path': parsed_json_path,
+        }
 
     def __store_remote_response(self, incoming_event):
         """
@@ -431,31 +460,26 @@ class MessageAdapter:
         replace_config = event.get('ReplaceConfig', None)
         if not replace_config:
             return event
-
         # Set default value if FullMessage flag set
         if replace_config.get('FullMessage', False):
             replace_config['Path'] = '$'
 
-        source_path = replace_config['Path']
-        target_path = replace_config.get('TargetPath', replace_config['Path'])
-        max_size = replace_config.get('MaxSize', self.REMOTE_DEFAULT_MAX_SIZE)
+        replace_config_values = self.__parse_remote_config_from_event(replace_config)
 
         for key in self.CMA_CONFIG_KEYS:
             if event.get(key):
                 del event[key]
-
         cumulus_meta = deepcopy(event['cumulus_meta'])
-        parsed_json_path = parse(source_path)
-        replacement_data = parsed_json_path.find(event)
+        replacement_data = replace_config_values['parsed_json_path'].find(event)
         if len(replacement_data) != 1:
-            raise Exception(f'JSON path invalid: {parsed_json_path}')
+            raise Exception(f'JSON path invalid: {replace_config_values["parsed_json_path"]}')
         replacement_data = replacement_data[0]
 
         estimated_data_size = len(json.dumps(replacement_data.value))
         if sys.version_info.major > 3:
             estimated_data_size = len(json.dumps(replacement_data.value).encode(('utf-8')))
 
-        if estimated_data_size < max_size:
+        if estimated_data_size < replace_config_values['max_size']:
             return event
 
         _s3 = s3()
@@ -470,10 +494,10 @@ class MessageAdapter:
         try:
             replacement_data.value.clear()
         except AttributeError:
-            parsed_json_path.update(event, '')
+            replace_config_values['parsed_json_path'].update(event, '')
 
         remote_configuration = {'Bucket': s3_bucket, 'Key': s3_key,
-                                'TargetPath': target_path}
+                                'TargetPath': replace_config_values['target_path']}
         event['cumulus_meta'] = event.get('cumulus_meta', cumulus_meta)
         event['replace'] = remote_configuration
         return event

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -29,7 +29,7 @@ class MessageAdapter:
     def __parse_parameter_configuration(event):
         parsed_event = event
         if event.get('cma'):
-            updated_event = {k: v for (k, v) in event['cma'].items() if k != 'event'}
+            updated_event = {k: v for (k,v) in event['cma'].items() if k != 'event'}
             parsed_event = event['cma']['event']
             parsed_event.update(updated_event)
         return parsed_event

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -29,7 +29,7 @@ class MessageAdapter:
     def __parse_parameter_configuration(event):
         parsed_event = event
         if event.get('cma'):
-            updated_event = {k: v for (k,v) in event['cma'].items() if k != 'event'}
+            updated_event = {k: v for (k, v) in event['cma'].items() if k != 'event'}
             parsed_event = event['cma']['event']
             parsed_event.update(updated_event)
         return parsed_event

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+from jsonpath_ng import parse
+
+
+def assign_json_path_value(source_message, jspath, value):
+    """
+    * Assign (update or insert) a value to message based on jsonpath.
+    * Create the keys if jspath doesn't already exist in the message. In this case, we
+    * support 'simple' jsonpath like $.path1.path2.path3....
+    * @param {*} message The message to be update
+    * @return {*} updated message
+    """
+    message = deepcopy(source_message)
+    if not parse(jspath).find(message):
+        paths = jspath.lstrip('$.').split('.')
+        current_item = message
+        key_not_found = False
+        for path in paths:
+            if key_not_found or path not in current_item:
+                key_not_found = True
+                new_path_dict = {}
+                # Add missing key to existing dict
+                current_item[path] = new_path_dict
+                # Set current item to newly created dict
+                current_item = new_path_dict
+            else:
+                current_item = current_item[path]
+    parse(jspath).update(message, value)
+    return message

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -7,7 +7,9 @@ def assign_json_path_value(source_message, jspath, value):
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if jspath doesn't already exist in the message. In this case, we
     * support 'simple' jsonpath like $.path1.path2.path3....
-    * @param {*} message The message to be update
+    * @param {dict} source_message The message to be updated
+    * @param {string} jspath JSON path string
+    * @param {*} value Value to update to
     * @return {*} updated message
     """
     message = deepcopy(source_message)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ mock~=1.3
 pylint>=1.8.2
 flake8~=3.7.9
 autopep8~=1.5.0
+pylint_runner=~0.5.4
 jsonschema==2.6.0
 pyinstaller==3.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ mock~=1.3
 pylint>=1.8.2
 flake8~=3.7.9
 autopep8~=1.5.0
-pylint_runner=~0.5.4
+pylint_runner~=0.5.4
 jsonschema==2.6.0
 pyinstaller==3.6.0

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -6,7 +6,6 @@ import json
 import unittest
 from mock import patch
 from jsonschema.exceptions import ValidationError
-
 from message_adapter import aws, message_adapter
 
 
@@ -463,6 +462,7 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         if 'messageConfig' in msg:
             del msg['messageConfig']
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
+        import pdb; pdb.set_trace()
         assert result == out_msg
 
     def test_remote(self):
@@ -546,7 +546,7 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.s3.Bucket(bucket_name).delete()
         self.assertEqual(result, out_msg)
 
-    @patch.object(message_adapter, '_get_current_sfn_task')
+    @patch.object(message_adapter, 'get_current_sfn_task')
     def test_sfn(self, get_current_sfn_task_function):
         """ test sfn.input.json """
         get_current_sfn_task_function.return_value = "Example"
@@ -562,7 +562,7 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(message_adapter, '_get_current_sfn_task')
+    @patch.object(message_adapter, 'get_current_sfn_task')
     def test_context(self, get_current_sfn_task_function):
         """ test storing context metadata """
         get_current_sfn_task_function.return_value = "Example"
@@ -581,7 +581,7 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(message_adapter, '_get_current_sfn_task')
+    @patch.object(message_adapter, 'get_current_sfn_task')
     def test_inline_template(self, get_current_sfn_task_function):
         """ test inline_template.input.json """
         get_current_sfn_task_function.return_value = "Example"
@@ -611,7 +611,7 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(message_adapter, '_get_current_sfn_task')
+    @patch.object(message_adapter, 'get_current_sfn_task')
     def test_cumulus_context(self, get_current_sfn_task_function):
         """ test storing cumulus_context metadata """
         get_current_sfn_task_function.return_value = "Example"

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -462,7 +462,6 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         if 'messageConfig' in msg:
             del msg['messageConfig']
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
-        import pdb; pdb.set_trace()
         assert result == out_msg
 
     def test_remote(self):

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -10,7 +10,7 @@ from jsonschema.exceptions import ValidationError
 from message_adapter import aws, message_adapter
 
 
-class Test(unittest.TestCase):
+class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
     # pylint: disable=no-member, protected-access
     """ Test class """
 
@@ -546,7 +546,7 @@ class Test(unittest.TestCase):
         self.s3.Bucket(bucket_name).delete()
         self.assertEqual(result, out_msg)
 
-    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    @patch.object(message_adapter, '_get_current_sfn_task')
     def test_sfn(self, get_current_sfn_task_function):
         """ test sfn.input.json """
         get_current_sfn_task_function.return_value = "Example"
@@ -562,7 +562,7 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    @patch.object(message_adapter, '_get_current_sfn_task')
     def test_context(self, get_current_sfn_task_function):
         """ test storing context metadata """
         get_current_sfn_task_function.return_value = "Example"
@@ -581,7 +581,7 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    @patch.object(message_adapter, '_get_current_sfn_task')
     def test_inline_template(self, get_current_sfn_task_function):
         """ test inline_template.input.json """
         get_current_sfn_task_function.return_value = "Example"
@@ -611,7 +611,7 @@ class Test(unittest.TestCase):
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
-    @patch.object(cumulus_message_adapter, '_MessageAdapter__get_current_sfn_task')
+    @patch.object(message_adapter, '_get_current_sfn_task')
     def test_cumulus_context(self, get_current_sfn_task_function):
         """ test storing cumulus_context metadata """
         get_current_sfn_task_function.return_value = "Example"

--- a/tests/test-program.py
+++ b/tests/test-program.py
@@ -38,7 +38,7 @@ class Test(unittest.TestCase):
         self.s3.Bucket(bucket_name).delete_objects(Delete=delete_objects_object)
         self.s3.Bucket(bucket_name).delete()
 
-    def execute_command(self, cmd, input_message):
+    def execute_command(self, cmd, input_message):  # pylint: disable=no-self-use
         """
         execute an external command command, and returns command exit status, stdout and stderr
         """


### PR DESCRIPTION
This refactor is a follow-on to #68 , and includes a reorganization of the module to pull as many class methods that shouldn't be out of the MessageAdapter class into several adjacent modules in the message_adapter module, with the goal of future refactors.  

Additionally the CI was updated start linting using pylinter, as it fixes an apparent long-standing bug in the CI that was causing that to fail silently. 

This change should be test code-coverage neutral. 
  Full update of unit tests is out-scope for this ticket - https://bugs.earthdata.nasa.gov/browse/CUMULUS-1746 has been written to address additional testing concerns. 