### PR TITLE
Jk/cumulus 2751 fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,9 @@ workflows:
           requires:
             - build_python36
             - build_python38
+          filters:
+            branches:
+              only: master
       - publish_pypi:
           requires:
             - publish_github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ jobs:
               pip install --user virtualenv
               ~/.local/bin/virtualenv ~/venv36
               . ~/venv36/bin/activate
-              # sudo pip install pyinstaller
               sudo pip install -r requirements.txt
               make clean
               make $ZIPFILENAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             VERSION=`awk -F\' '{print $2,$4}' message_adapter/version.py`
-            echo $VERSION
             # Only tag and release if the version doesn't already exist
             if [ -z $(git ls-remote --tags origin | grep $VERSION) ]; then
               git tag $VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,6 @@ workflows:
           requires:
             - build_python36
             - build_python38
-          filters:
-            branches:
-              only: master
       - publish_pypi:
           requires:
             - publish_github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             VERSION=`awk -F\' '{print $2,$4}' message_adapter/version.py`
+            echo $VERSION
             # Only tag and release if the version doesn't already exist
             if [ -z $(git ls-remote --tags origin | grep $VERSION) ]; then
               git tag $VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
               pip install --user virtualenv
               ~/.local/bin/virtualenv ~/venv36
               . ~/venv36/bin/activate
-              sudo pip install pyinstaller
+              # sudo pip install pyinstaller
               sudo pip install -r requirements.txt
               make clean
               make $ZIPFILENAME


### PR DESCRIPTION
This PR removes an unneeded installation of pyinstaller from the main script.   This package is installed via the Makefile from the *pinned* dependency in requirements-dev.txt, whereas this line installs it first >globally< without the pin.      I believe it can be safely removed. 

I set the CI to build with this line commented out here: https://app.circleci.com/pipelines/github/nasa/cumulus-message-adapter/47/workflows/86ffe1b2-79b6-4dfa-bc70-9af1296f7103 and it successfully built the CMA .zip.    I was able to successfully deploy core and run integration tests against Core lambdas that show this works. 