### PR TITLE
Feature implemented from feature request #82

### DIFF
--- a/examples/messages/jsonpath_array.input.json
+++ b/examples/messages/jsonpath_array.input.json
@@ -1,12 +1,19 @@
 {
   "task_config": {
-    "bar": "baz",
     "cumulus_message": {
       "input": "{$.payload.input}",
       "outputs": [
         {
-          "source": "{$.input.anykey}",
-          "destination": "{$.payload.out}"
+          "source": "{[$.input.granules[*].version]}",
+          "destination": "{[$.payload.output.granules[*].versionRenamed]}"
+        },
+        {
+          "source": "{[$.input.granules[*].files[*].filename]}",
+          "destination": "{[$.payload.output.granules[*].files[*].filenameRenamed]}"
+        },
+        {
+          "source": "{[$.input.granules[*].files[*].filepath]}",
+          "destination": "{[$.payload.output.granules[*].files[*].filepathRenamed]}"
         }
       ]
     }
@@ -15,12 +22,40 @@
     "message_source": "local",
     "id": "id-1234"
   },
-  "meta": {
-    "foo": "bar"
-  },
   "payload": {
     "input": {
-      "anykey": "anyvalue"
+       "granules":[
+          {
+             "version":"A",
+             "files":[
+                {
+                   "filename":"s3://cumulus-bucket/cumulus-object-A1",
+                   "filepath":"cumulus/path/A1"
+                },
+                {
+                   "filename":"s3://cumulus-bucket/cumulus-object-A2",
+                   "filepath":"cumulus/path/A2"
+                },
+                {
+                   "filename":"s3://cumulus-bucket/cumulus-object-A3",
+                   "filepath":"cumulus/path/A3"
+                }
+             ]
+          },
+          {
+             "version":"B",
+             "files":[
+                {
+                   "filename":"s3://cumulus-bucket/cumulus-object-B1",
+                   "filepath":"cumulus/path/B1"
+                },
+                {
+                   "filename":"s3://cumulus-bucket/cumulus-object-B2",
+                   "filepath":"cumulus/path/B2"
+                }
+             ]
+          }
+       ]
     }
   }
 }

--- a/examples/messages/jsonpath_array.input.json
+++ b/examples/messages/jsonpath_array.input.json
@@ -1,0 +1,26 @@
+{
+  "task_config": {
+    "bar": "baz",
+    "cumulus_message": {
+      "input": "{$.payload.input}",
+      "outputs": [
+        {
+          "source": "{$.input.anykey}",
+          "destination": "{$.payload.out}"
+        }
+      ]
+    }
+  },
+  "cumulus_meta": {
+    "message_source": "local",
+    "id": "id-1234"
+  },
+  "meta": {
+    "foo": "bar"
+  },
+  "payload": {
+    "input": {
+      "anykey": "anyvalue"
+    }
+  }
+}

--- a/examples/messages/jsonpath_array.input.json
+++ b/examples/messages/jsonpath_array.input.json
@@ -1,61 +1,55 @@
 {
-  "task_config": {
-    "cumulus_message": {
-      "input": "{$.payload.input}",
-      "outputs": [
-        {
-          "source": "{[$.input.granules[*].version]}",
-          "destination": "{[$.payload.output.granules[*].versionRenamed]}"
-        },
-        {
-          "source": "{[$.input.granules[*].files[*].filename]}",
-          "destination": "{[$.payload.output.granules[*].files[*].filenameRenamed]}"
-        },
-        {
-          "source": "{[$.input.granules[*].files[*].filepath]}",
-          "destination": "{[$.payload.output.granules[*].files[*].filepathRenamed]}"
-        }
-      ]
-    }
-  },
-  "cumulus_meta": {
-    "message_source": "local",
-    "id": "id-1234"
-  },
-  "payload": {
-    "input": {
-       "granules":[
-          {
-             "version":"A",
-             "files":[
-                {
-                   "filename":"s3://cumulus-bucket/cumulus-object-A1",
-                   "filepath":"cumulus/path/A1"
-                },
-                {
-                   "filename":"s3://cumulus-bucket/cumulus-object-A2",
-                   "filepath":"cumulus/path/A2"
-                },
-                {
-                   "filename":"s3://cumulus-bucket/cumulus-object-A3",
-                   "filepath":"cumulus/path/A3"
-                }
-             ]
-          },
-          {
-             "version":"B",
-             "files":[
-                {
-                   "filename":"s3://cumulus-bucket/cumulus-object-B1",
-                   "filepath":"cumulus/path/B1"
-                },
-                {
-                   "filename":"s3://cumulus-bucket/cumulus-object-B2",
-                   "filepath":"cumulus/path/B2"
-                }
-             ]
-          }
-       ]
-    }
-  }
+   "task_config":{
+      "cumulus_message":{
+         "input":"{$.payload.input}",
+         "outputs":[
+            {
+               "source":"{[$.input.array1[*].array2[*].itemA]}",
+               "destination":"{[$.payload.output.array1[*].array2[*].newItemA]}"
+            },
+            {
+               "source":"{[$.input.array1[*].array2[*].itemB]}",
+               "destination":"{[$.payload.output.array1[*].pathInsertedForItemB.array2[*].newItemB]}"
+            }
+         ]
+      }
+   },
+   "cumulus_meta":{
+      "message_source":"local",
+      "id":"id-1234"
+   },
+   "payload":{
+      "input":{
+         "array1":[
+            {
+               "array2":[
+                  {
+                     "itemA":"11A",
+                     "itemB":"11B"
+                  },
+                  {
+                     "itemA":"12A",
+                     "itemB":"12B"
+                  },
+                  {
+                     "itemA":"13A",
+                     "itemB":"13B"
+                  }
+               ]
+            },
+            {
+               "array2":[
+                  {
+                     "itemA":"21A",
+                     "itemB":"21B"
+                  },
+                  {
+                     "itemA":"22A",
+                     "itemB":"22B"
+                  }
+               ]
+            }
+         ]
+      }
+   }
 }

--- a/examples/messages/jsonpath_array.output.json
+++ b/examples/messages/jsonpath_array.output.json
@@ -1,0 +1,25 @@
+{
+  "task_config": {
+    "bar": "baz",
+    "cumulus_message": {
+      "input": "{$.payload.input}",
+      "outputs": [
+        {
+          "source": "{$.input.anykey}",
+          "destination": "{$.payload.out}"
+        }
+      ]
+    }
+  },
+  "cumulus_meta": {
+    "message_source": "local",
+    "id": "id-1234"
+  },
+  "meta": {
+    "foo": "bar"
+  },
+  "payload": {
+    "out": "anyvalue"
+  },
+  "exception": "None"
+}

--- a/examples/messages/jsonpath_array.output.json
+++ b/examples/messages/jsonpath_array.output.json
@@ -6,36 +6,52 @@
    "exception":"None",
    "payload":{
       "output":{
-         "granules":[
+         "array1":[
             {
-               "files":[
+               "array2":[
                   {
-                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A1",
-                     "filepathRenamed":"cumulus/path/A1"
+                     "newItemA":"11A"
                   },
                   {
-                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A2",
-                     "filepathRenamed":"cumulus/path/A2"
+                     "newItemA":"12A"
                   },
                   {
-                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A3",
-                     "filepathRenamed":"cumulus/path/A3"
+                     "newItemA":"13A"
                   }
                ],
-               "versionRenamed":"A"
+               "pathInsertedForItemB":{
+                  "array2":[
+                     {
+                        "newItemB":"11B"
+                     },
+                     {
+                        "newItemB":"12B"
+                     },
+                     {
+                        "newItemB":"13B"
+                     }
+                  ]
+               }
             },
             {
-               "files":[
+               "array2":[
                   {
-                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-B1",
-                     "filepathRenamed":"cumulus/path/B1"
+                     "newItemA":"21A"
                   },
                   {
-                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-B2",
-                     "filepathRenamed":"cumulus/path/B2"
+                     "newItemA":"22A"
                   }
                ],
-               "versionRenamed":"B"
+               "pathInsertedForItemB":{
+                  "array2":[
+                     {
+                        "newItemB":"21B"
+                     },
+                     {
+                        "newItemB":"22B"
+                     }
+                  ]
+               }
             }
          ]
       }
@@ -45,16 +61,12 @@
          "input":"{$.payload.input}",
          "outputs":[
             {
-               "destination":"{[$.payload.output.granules[*].versionRenamed]}",
-               "source":"{[$.input.granules[*].version]}"
+               "destination":"{[$.payload.output.array1[*].array2[*].newItemA]}",
+               "source":"{[$.input.array1[*].array2[*].itemA]}"
             },
             {
-               "destination":"{[$.payload.output.granules[*].files[*].filenameRenamed]}",
-               "source":"{[$.input.granules[*].files[*].filename]}"
-            },
-            {
-               "destination":"{[$.payload.output.granules[*].files[*].filepathRenamed]}",
-               "source":"{[$.input.granules[*].files[*].filepath]}"
+               "destination":"{[$.payload.output.array1[*].pathInsertedForItemB.array2[*].newItemB]}",
+               "source":"{[$.input.array1[*].array2[*].itemB]}"
             }
          ]
       }

--- a/examples/messages/jsonpath_array.output.json
+++ b/examples/messages/jsonpath_array.output.json
@@ -1,25 +1,62 @@
 {
-  "task_config": {
-    "bar": "baz",
-    "cumulus_message": {
-      "input": "{$.payload.input}",
-      "outputs": [
-        {
-          "source": "{$.input.anykey}",
-          "destination": "{$.payload.out}"
-        }
-      ]
-    }
-  },
-  "cumulus_meta": {
-    "message_source": "local",
-    "id": "id-1234"
-  },
-  "meta": {
-    "foo": "bar"
-  },
-  "payload": {
-    "out": "anyvalue"
-  },
-  "exception": "None"
+   "cumulus_meta":{
+      "id":"id-1234",
+      "message_source":"local"
+   },
+   "exception":"None",
+   "payload":{
+      "output":{
+         "granules":[
+            {
+               "files":[
+                  {
+                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A1",
+                     "filepathRenamed":"cumulus/path/A1"
+                  },
+                  {
+                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A2",
+                     "filepathRenamed":"cumulus/path/A2"
+                  },
+                  {
+                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-A3",
+                     "filepathRenamed":"cumulus/path/A3"
+                  }
+               ],
+               "versionRenamed":"A"
+            },
+            {
+               "files":[
+                  {
+                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-B1",
+                     "filepathRenamed":"cumulus/path/B1"
+                  },
+                  {
+                     "filenameRenamed":"s3://cumulus-bucket/cumulus-object-B2",
+                     "filepathRenamed":"cumulus/path/B2"
+                  }
+               ],
+               "versionRenamed":"B"
+            }
+         ]
+      }
+   },
+   "task_config":{
+      "cumulus_message":{
+         "input":"{$.payload.input}",
+         "outputs":[
+            {
+               "destination":"{[$.payload.output.granules[*].versionRenamed]}",
+               "source":"{[$.input.granules[*].version]}"
+            },
+            {
+               "destination":"{[$.payload.output.granules[*].files[*].filenameRenamed]}",
+               "source":"{[$.input.granules[*].files[*].filename]}"
+            },
+            {
+               "destination":"{[$.payload.output.granules[*].files[*].filepathRenamed]}",
+               "source":"{[$.input.granules[*].files[*].filepath]}"
+            }
+         ]
+      }
+   }
 }

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from jsonschema import validate
 from .aws import get_current_sfn_task
 
-from .util import assign_json_path_value
+from .util import assign_json_path_value, assign_json_path_values
 from .cumulus_message import (resolve_config_templates, resolve_input,
                               resolve_path_str, load_config, load_remote_event,
                               store_remote_response)
@@ -146,7 +146,10 @@ class MessageAdapter:
                 dest_path = output['destination']
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
                 value = resolve_path_str(handler_response, source_path)
-                result = assign_json_path_value(result, dest_json_path, value)
+                if not isinstance(value, list):
+                    result = assign_json_path_value(result, dest_json_path, value)
+                else:
+                    result = assign_json_path_values(result, dest_json_path, value)
         else:
             result['payload'] = handler_response
 

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -149,8 +149,8 @@ class MessageAdapter:
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
                 value = resolve_path_str(handler_response, source_path)
                 if re.match(r'^\[.*\]$', dest_json_path):
-                    #source_json_path = source_json_path.lstrip('[').rstrip(']')
-                    #dest_json_path = dest_json_path.lstrip('[').rstrip(']')
+                    source_json_path = source_json_path.lstrip('[').rstrip(']')
+                    dest_json_path = dest_json_path.lstrip('[').rstrip(']')
                     result = assign_json_path_values(handler_response, source_json_path, result, dest_json_path, value)
                 else:
                     result = assign_json_path_value(result, dest_json_path, value)

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -150,7 +150,7 @@ class MessageAdapter:
                 if not isinstance(value, list):
                     result = assign_json_path_value(result, dest_json_path, value)
                 else:
-                    result = assign_json_path_values(handler_response, result, source_json_path, dest_json_path, value)
+                    result = assign_json_path_values(handler_response, source_json_path, result, dest_json_path, value)
         else:
             result['payload'] = handler_response
 

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -151,7 +151,9 @@ class MessageAdapter:
                 if re.match(r'^\[.*\]$', dest_json_path):
                     source_json_path = source_json_path.lstrip('[').rstrip(']')
                     dest_json_path = dest_json_path.lstrip('[').rstrip(']')
-                    result = assign_json_path_values(handler_response, source_json_path, result, dest_json_path, value)
+                    result = assign_json_path_values(
+                        handler_response, source_json_path, result, dest_json_path, value
+                    )
                 else:
                     result = assign_json_path_value(result, dest_json_path, value)
         else:

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 
 from copy import deepcopy
 from jsonschema import validate
@@ -147,10 +148,10 @@ class MessageAdapter:
                 dest_path = output['destination']
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
                 value = resolve_path_str(handler_response, source_path)
-                if not isinstance(value, list):
-                    result = assign_json_path_value(result, dest_json_path, value)
-                else:
+                if re.match(r'^\[.*\]$', dest_json_path):
                     result = assign_json_path_values(handler_response, source_json_path, result, dest_json_path, value)
+                else:
+                    result = assign_json_path_value(result, dest_json_path, value)
         else:
             result['payload'] = handler_response
 

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -144,11 +144,13 @@ class MessageAdapter:
             result['payload'] = {}
             for output in outputs:
                 source_path = output['source']
-                source_json_path = output['source'].lstrip('{').rstrip('}')
+                source_json_path = source_path.lstrip('{').rstrip('}')
                 dest_path = output['destination']
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
                 value = resolve_path_str(handler_response, source_path)
                 if re.match(r'^\[.*\]$', dest_json_path):
+                    #source_json_path = source_json_path.lstrip('[').rstrip(']')
+                    #dest_json_path = dest_json_path.lstrip('[').rstrip(']')
                     result = assign_json_path_values(handler_response, source_json_path, result, dest_json_path, value)
                 else:
                     result = assign_json_path_value(result, dest_json_path, value)

--- a/message_adapter/message_adapter.py
+++ b/message_adapter/message_adapter.py
@@ -143,13 +143,14 @@ class MessageAdapter:
             result['payload'] = {}
             for output in outputs:
                 source_path = output['source']
+                source_json_path = output['source'].lstrip('{').rstrip('}')
                 dest_path = output['destination']
                 dest_json_path = dest_path.lstrip('{').rstrip('}')
                 value = resolve_path_str(handler_response, source_path)
                 if not isinstance(value, list):
                     result = assign_json_path_value(result, dest_json_path, value)
                 else:
-                    result = assign_json_path_values(result, dest_json_path, value)
+                    result = assign_json_path_values(handler_response, result, source_json_path, dest_json_path, value)
         else:
             result['payload'] = handler_response
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -36,7 +36,7 @@ def assign_json_path_value(message_for_update, jspath, value):
     return message
 
 
-def assign_json_path_values(source_message, message_for_update, source_jspath, dest_jspath, value):
+def assign_json_path_values(source_message, source_jspath, message_for_update, dest_jspath, value):
     """
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if dest_jspath doesn't already exist in the message. In this case, we

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from pprint import pprint
 from jsonpath_ng import parse
 
 
@@ -13,19 +14,54 @@ def assign_json_path_value(source_message, jspath, value):
     * @return {*} updated message
     """
     message = deepcopy(source_message)
+    if jspath[0]=='[':
+        jspath = jspath.lstrip('[').rstrip(']')
+    flag_array_jspath = False
     if not parse(jspath).find(message):
         paths = jspath.lstrip('$.').split('.')
         current_item = message
         key_not_found = False
         for path in paths:
-            if key_not_found or path not in current_item:
-                key_not_found = True
-                new_path_dict = {}
-                # Add missing key to existing dict
-                current_item[path] = new_path_dict
-                # Set current item to newly created dict
-                current_item = new_path_dict
+            flag_array = False
+            if '[' in path:
+                path = path.split('[')[0]
+                flag_array = True
+                flag_array_jspath = True
+            print(path)
+            pprint(type(current_item))
+            if isinstance(current_item, list):
+                current_items = current_item
+                for current_item in current_items:
+                    if key_not_found or path not in current_item:
+                        key_not_found = True
+                        if flag_array:
+                            new_path_dict = []
+                        else:
+                            new_path_dict = {}
+                        # Add missing key to existing dict
+                        current_item[path] = new_path_dict
+                        # Set current item to newly created dict
+                        current_item = new_path_dict
+                    else:
+                        current_item = current_item[path]
             else:
-                current_item = current_item[path]
-    parse(jspath).update(message, value)
+                if key_not_found or path not in current_item:
+                    key_not_found = True
+                    if flag_array:
+                        new_path_dict = []
+                    else:
+                        new_path_dict = {}
+                    # Add missing key to existing dict
+                    current_item[path] = new_path_dict
+                    # Set current item to newly created dict
+                    current_item = new_path_dict
+                else:
+                    current_item = current_item[path]
+    if flag_array_jspath:
+        #parse(jspath).update(message, value)
+        match_data = parse(jspath).find(message)
+        for item,v in zip(match_data,value):
+            item.full_path.update(message,v)
+    else:
+        parse(jspath).update(message, value)
     return message

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -33,6 +33,10 @@ def assign_json_path_value(message_for_update, jspath, value):
     return message
 
 
+def __sanitize_path(path):
+    m = re.match('^(.*)\[\*\]$', path)
+    return m.groups()[0] if m else path
+    
 def assign_json_path_values(
     source_message, source_jspath, message_for_update, dest_jspath, value
 ):
@@ -45,6 +49,27 @@ def assign_json_path_values(
     * @param {*} value Value to update to
     * @return {*} updated message
     """
+    message = deepcopy(message_for_update)
+
+    # Find where source_jspath and dest_jspath begin to diverge
+    source_paths = source_jspath.lstrip('$.').split('.')
+    dest_paths = dest_jspath.lstrip('$.').split('.')
+    idx_diverged = len(source_paths)
+    for idx, (source_path, dest_path) in enumerate(zip(source_paths, dest_paths)):
+        if __sanitize_path(source_path) != __sanitize_path(dest_path):
+            idx_diverged = idx
+            break
+
+    # Copy items from source to destination
+    # before their jsonpath begin to diverge
+    for idx in range(idx_diverged):
+        pass # Don't need to do anything?
+
+    # 
+    for idx in range(idx_diverged, len(dest_paths)):
+
+
+
     # Collect array info from jspath
     array_regex = r"([^$\.\]\[\*]+)\[\*\]"
     source_jspath_array_names = re.findall(array_regex, source_jspath)
@@ -60,9 +85,26 @@ def assign_json_path_values(
         partial_jspath = source_jspath[:source_jspath_array_index] + source_jspath_array_name
         ns = [m.value for m in parse_ext(partial_jspath + '.`len`').find(source_message)]
 
+
+    if not parse(jspath).find(message):
+        paths = jspath.lstrip('$.').split('.')
+        current_item = message
+        key_not_found = False
+        for path in paths:
+            m = re.match('^(.*)\[\*\]$', path)
+            if m: path = m.groups(0)
+            if key_not_found or path not in current_item:
+                key_not_found = True
+                new_path_dict = {}
+                # Add missing key to existing dict
+                current_item[path] = new_path_dict
+                # Set current item to newly created dict
+                current_item = new_path_dict
+            else:
+                current_item = current_item[path]
+
+    '''
     message = deepcopy(message_for_update)
-    if dest_jspath[0] == "[":
-        dest_jspath = dest_jspath.lstrip("[").rstrip("]")
     flag_array_jspath = False
     if not parse(dest_jspath).find(message):
         paths = dest_jspath.lstrip("$.").split(".")
@@ -109,4 +151,6 @@ def assign_json_path_values(
             item.full_path.update(message, v)
     else:
         parse(dest_jspath).update(message, value)
+    '''
+
     return message

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -41,7 +41,7 @@ class ArrayPathTree:
     def __init__(self, val="", node_idx=0, is_root=False):
         self.val = val
         if not is_root:
-            self.val += '['+str(node_idx)+']'
+            self.val += "[" + str(node_idx) + "]"
         self.children = []
 
     def add_child(self, val, node_idx):
@@ -52,18 +52,19 @@ class ArrayPathTree:
 
 def build_jspath_recursively(root, path_list, path, tree_level):
 
-    if(len(path) > tree_level):
+    if len(path) > tree_level:
         path[tree_level] = root.val
     else:
         path.append(root.val)
-  
+
     if root.children:
         tree_level = tree_level + 1
         for child in root.children:
             build_jspath_recursively(child, path_list, path, tree_level)
     else:
         path_list.append(deepcopy(path))
- 
+
+
 def assign_json_path_values(
     source_message, source_jspath, message_for_update, dest_jspath, value
 ):
@@ -98,26 +99,33 @@ def assign_json_path_values(
     #    /   |   \    /     \
     # C[0] C[1] C[2] C[0]   C[1]
     #
-    source_jspath_arrays = source_jspath.split('[*]')[:-1]
-    dest_jspath_arrays = [m.lstrip('$').strip('.') for m in dest_jspath.split('[*]')][:-1]
-    #array_regex = r"([^$\]\[\*]+)\[\*\]"
-    #print("ZHL ",dest_jspath_arrays, re.findall(array_regex, dest_jspath))
+    source_jspath_arrays = source_jspath.split("[*]")[:-1]
+    dest_jspath_arrays = [m.lstrip("$").strip(".") for m in dest_jspath.split("[*]")][
+        :-1
+    ]
+    # array_regex = r"([^$\]\[\*]+)\[\*\]"
+    # print("ZHL ",dest_jspath_arrays, re.findall(array_regex, dest_jspath))
     if len(source_jspath_arrays) != len(dest_jspath_arrays):
         raise ValueError(
             "inconsistent number of arrays found from the output source and destination path in CMA"
         )
-    root = ArrayPathTree('$', 0, is_root=True)
+    root = ArrayPathTree("$", 0, is_root=True)
     parents = [root]
-    for idx, (source_jspath_array, dest_jspath_array) in enumerate(zip(source_jspath_arrays, dest_jspath_arrays)):
-        source_jspath_partial = '$.' + '[*].'.join(source_jspath_arrays[:idx+1])
-        nums_children = [m.value for m in parse_ext(source_jspath_partial+ '.`len`').find(source_message)]
+    for idx, (source_jspath_array, dest_jspath_array) in enumerate(
+        zip(source_jspath_arrays, dest_jspath_arrays)
+    ):
+        source_jspath_partial = "$." + "[*].".join(source_jspath_arrays[: idx + 1])
+        nums_children = [
+            m.value
+            for m in parse_ext(source_jspath_partial + ".`len`").find(source_message)
+        ]
         if len(nums_children) != len(parents):
             raise Exception("Something goes wrong")
         children = []
         count = 0
         for i, parent in enumerate(parents):
             for j in range(nums_children[i]):
-                child = parent.add_child(dest_jspath_array,j )
+                child = parent.add_child(dest_jspath_array, j)
                 children.append(child)
                 count += 1
         parents = children
@@ -129,7 +137,7 @@ def assign_json_path_values(
     # Update the jspath
     count = 0
     for path in path_list:
-        jspath = '.'.join(path) + dest_jspath.split('[*]')[-1] #NOTE not clean
+        jspath = ".".join(path) + dest_jspath.split("[*]")[-1]  # NOTE not clean
         parse_ext(jspath).update_or_create(message, value[count])
         count += 1
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -47,14 +47,18 @@ def assign_json_path_values(
     """
     # Collect array info from jspath
     array_regex = r"([^$\.\]\[\*]+)\[\*\]"
-    source_array = re.findall(array_regex, source_jspath)
-    dest_array = re.findall(array_regex, dest_jspath)
-    if len(source_array) != len(dest_array):
+    source_jspath_array_names = re.findall(array_regex, source_jspath)
+    source_jspath_array_indices = [m.start(0) for m in re.finditer(array_regex, source_jspath)]
+    dest_jspath_arrays = re.findall(array_regex, dest_jspath)
+    if len(source_jspath_array_names) != len(dest_jspath_arrays):
         raise ValueError(
             "inconsistent number of arrays found from the output source and destination path in CMA"
         )
 
-    # Get the hierarchy of array size from dest_jspath
+    # Get the hierarchy of array size from source_jspath
+    for (source_jspath_array_name, source_jspath_array_index) in zip(source_jspath_array_names, source_jspath_array_indices):
+        partial_jspath = source_jspath[:source_jspath_array_index] + source_jspath_array_name
+        ns = [m.value for m in parse_ext(partial_jspath + '.`len`').find(source_message)]
 
     message = deepcopy(message_for_update)
     if dest_jspath[0] == "[":

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -83,17 +83,21 @@ def assign_json_path_values(
     #   and the subsequent levels are partitioned by the array components of the jsonpath
     # The degree of a tree node is determined by the number of elements from source_jsonpath
     # E.g., for a source_jsonpath of "$.X[*].Y[*]" and a dest_jsonpath of "$.A.B[*].C[*]",
-    #   the tree structure would be:
+    #   if the array size is 2 for "$.X[*]", 3 for "$.X[0].Y[*]", and 2 for "$.X[1].Y[*]",
+    #   the tree structure will be:
+    #
     #              $
     #             / \
     #            /   \
     #           /     \
     #          /       \
+    #         /         \
     #      A.B[0]       A.B[1]
     #      / | \        / \
     #     /  |  \      /   \
     #    /   |   \    /     \
     # C[0] C[1] C[2] C[0]   C[1]
+    #
     source_jspath_arrays = source_jspath.split('[*]')[:-1]
     dest_jspath_arrays = [m.strip('.') for m in dest_jspath.split('[*]')][:-1]
     if len(source_jspath_arrays) != len(dest_jspath_arrays):

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -35,20 +35,22 @@ def assign_json_path_value(message_for_update, jspath, value):
 
 class JspathTree:
 
-    def __init__(self, idx=0, val=""):
+    def __init__(self, idx=0, val="", is_array=False):
         self.idx = idx
-        self.val = val+'['+str(idx)+']'
+        self.val = val
+        if is_array:
+            self.val += '['+str(idx)+']'
         self.children = []
 
     def add_child(self, idx, val):
-        child = JspathTree(idx, val)
+        child = JspathTree(idx, val, True)
         self.children.append(child)
         return child
 
 
 # Helper function to print path from root
 # to leaf in binary tree
-def printPathsRec(root, path, pathLen):
+def printPathsRec(root, path_list, path, pathLen):
      
     # Base condition - if binary tree is
     # empty return
@@ -71,10 +73,14 @@ def printPathsRec(root, path, pathLen):
          
         # leaf node then print the list
         printArray(path, pathLen)
+        print("indside path: ",path)
+        print("indside list before: ",path_list)
+        path_list.append(deepcopy(path))
+        print("indside list after : ",path_list)
     else:
         # try for left and right subtree
         for child in root.children:
-            printPathsRec(child, path, pathLen)
+            printPathsRec(child, path_list, path, pathLen)
  
 # Helper function to print list in which
 # root-to-leaf path is stored
@@ -105,7 +111,7 @@ def assign_json_path_values(
         raise ValueError(
             "inconsistent number of arrays found from the output source and destination path in CMA"
         )
-    root = JspathTree('$.')
+    root = JspathTree(0, '$.')
     parents = [root]
     for idx, (source_jspath_array, dest_jspath_array) in enumerate(zip(source_jspath_arrays, dest_jspath_arrays)):
         source_jspath_partial = '$.' + '[*].'.join(source_jspath_arrays[:idx+1])
@@ -121,7 +127,9 @@ def assign_json_path_values(
                 count += 1
         parents = children
 
-    printPathsRec(root, [], 0)
+    path_list = []
+    printPathsRec(root, path_list, [], 0)
+    from pprint import pprint; pprint(path_list)
     import sys; sys.exit(0)
 
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -38,14 +38,14 @@ class ArrayPathTree:
     Tree implementation which saves the array part of the jsonpath
     """
 
-    def __init__(self, idx=0, val="", is_root=False):
+    def __init__(self, val="", node_idx=0, is_root=False):
         self.val = val
         if not is_root:
-            self.val += '['+str(idx)+']'
+            self.val += '['+str(node_idx)+']'
         self.children = []
 
-    def add_child(self, idx, val):
-        child = ArrayPathTree(idx, val)
+    def add_child(self, val, node_idx):
+        child = ArrayPathTree(val, node_idx)
         self.children.append(child)
         return child
 
@@ -106,7 +106,7 @@ def assign_json_path_values(
         raise ValueError(
             "inconsistent number of arrays found from the output source and destination path in CMA"
         )
-    root = ArrayPathTree(0, '$', is_root=True)
+    root = ArrayPathTree('$', 0, is_root=True)
     parents = [root]
     for idx, (source_jspath_array, dest_jspath_array) in enumerate(zip(source_jspath_arrays, dest_jspath_arrays)):
         source_jspath_partial = '$.' + '[*].'.join(source_jspath_arrays[:idx+1])
@@ -117,7 +117,7 @@ def assign_json_path_values(
         count = 0
         for i, parent in enumerate(parents):
             for j in range(nums_children[i]):
-                child = parent.add_child(j, dest_jspath_array)
+                child = parent.add_child(dest_jspath_array,j )
                 children.append(child)
                 count += 1
         parents = children

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -3,7 +3,40 @@ from pprint import pprint
 from jsonpath_ng import parse
 
 
+from copy import deepcopy
+from jsonpath_ng import parse
+
+
 def assign_json_path_value(source_message, jspath, value):
+    """
+    * Assign (update or insert) a value to message based on jsonpath.
+    * Create the keys if jspath doesn't already exist in the message. In this case, we
+    * support 'simple' jsonpath like $.path1.path2.path3....
+    * @param {dict} source_message The message to be updated
+    * @param {string} jspath JSON path string
+    * @param {*} value Value to update to
+    * @return {*} updated message
+    """
+    message = deepcopy(source_message)
+    if not parse(jspath).find(message):
+        paths = jspath.lstrip('$.').split('.')
+        current_item = message
+        key_not_found = False
+        for path in paths:
+            if key_not_found or path not in current_item:
+                key_not_found = True
+                new_path_dict = {}
+                # Add missing key to existing dict
+                current_item[path] = new_path_dict
+                # Set current item to newly created dict
+                current_item = new_path_dict
+            else:
+                current_item = current_item[path]
+    parse(jspath).update(message, value)
+    return message
+
+
+def assign_json_path_values(source_message, jspath, value):
     """
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if jspath doesn't already exist in the message. In this case, we

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -19,7 +19,7 @@ def assign_json_path_value(message_for_update, jspath, value):
     """
     message = deepcopy(message_for_update)
     if not parse(jspath).find(message):
-        paths = jspath.lstrip('$.').split('.')
+        paths = jspath.lstrip("$.").split(".")
         current_item = message
         key_not_found = False
         for path in paths:
@@ -36,7 +36,9 @@ def assign_json_path_value(message_for_update, jspath, value):
     return message
 
 
-def assign_json_path_values(source_message, source_jspath, message_for_update, dest_jspath, value):
+def assign_json_path_values(
+    source_message, source_jspath, message_for_update, dest_jspath, value
+):
     """
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if dest_jspath doesn't already exist in the message. In this case, we
@@ -47,17 +49,17 @@ def assign_json_path_values(source_message, source_jspath, message_for_update, d
     * @return {*} updated message
     """
     message = deepcopy(message_for_update)
-    if dest_jspath[0]=='[':
-        dest_jspath = dest_jspath.lstrip('[').rstrip(']')
+    if dest_jspath[0] == "[":
+        dest_jspath = dest_jspath.lstrip("[").rstrip("]")
     flag_array_jspath = False
     if not parse(dest_jspath).find(message):
-        paths = dest_jspath.lstrip('$.').split('.')
+        paths = dest_jspath.lstrip("$.").split(".")
         current_item = message
         key_not_found = False
         for path in paths:
             flag_array = False
-            if '[' in path:
-                path = path.split('[')[0]
+            if "[" in path:
+                path = path.split("[")[0]
                 flag_array = True
                 flag_array_jspath = True
             print(path)
@@ -91,10 +93,10 @@ def assign_json_path_values(source_message, source_jspath, message_for_update, d
                 else:
                     current_item = current_item[path]
     if flag_array_jspath:
-        #parse(dest_jspath).update(message, value)
+        # parse(dest_jspath).update(message, value)
         match_data = parse(dest_jspath).find(message)
-        for item,v in zip(match_data,value):
-            item.full_path.update(message,v)
+        for item, v in zip(match_data, value):
+            item.full_path.update(message, v)
     else:
         parse(dest_jspath).update(message, value)
     return message

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -123,6 +123,12 @@ def assign_json_path_values(
     path_list = []
     build_jspath_recursively(root, path_list, [], 0)
     from pprint import pprint; pprint(path_list)
+
+    #
+    for path in path_list:
+        jspath = '.'.join(path)
+        print(jspath)
+
     import sys; sys.exit(0)
 
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -45,6 +45,9 @@ class JsonpathArrayTree:
         self.children = []
 
     def add_child(self, val, node_idx):
+        """
+        Add and return a child
+        """
         child = JsonpathArrayTree(val, node_idx)
         self.children.append(child)
         return child

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -1,10 +1,7 @@
 from copy import deepcopy
+import re
 from jsonpath_ng import parse
 from jsonpath_ng.ext import parse as parse_ext
-
-
-from copy import deepcopy
-from jsonpath_ng import parse
 
 
 def assign_json_path_value(message_for_update, jspath, value):
@@ -48,6 +45,15 @@ def assign_json_path_values(
     * @param {*} value Value to update to
     * @return {*} updated message
     """
+    # Collect array info from jspath
+    array_regex = r"([^$\.\]\[\*]+)\[\*\]"
+    source_array = re.findall(array_regex, source_jspath)
+    dest_array = re.findall(array_regex, dest_jspath)
+    if len(source_array) != len(dest_array):
+        raise ValueError(
+            "inconsistent number of arrays found from the output source and destination path in CMA"
+        )
+
     # Get the hierarchy of array size from dest_jspath
 
     message = deepcopy(message_for_update)

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -95,10 +95,13 @@ def assign_json_path_values(
     *       and array "$.A.B[0].C[*]" with size of 3,
     *       and array "$.A.B[1].C[0]" with size of 6
     *   if array "$.A.B[*]" and "$.A.B[*].C[*]" already exist in destination message,
-    *       they will be directly updated, and no exception will be handled if the array size doesn't match
+    *       they will be directly updated,
+    *       and no exception will be handled if the array size doesn't match
     * Also note that "range indexing" is supported in source jsonpath (but not the destination)
-    * E.g., the source jsonpath in the above example can be "$.X[:2].Y[5:8]", "$.X[:2].Y[*]", or "$.X[*].Y[5:8]"
-    * @param {dict} source_message The source message used to get the array lengths (by parsing source_jspath)
+    * E.g., the source jsonpath in the above example can be "$.X[:2].Y[5:8]",
+    *       "$.X[:2].Y[*]", or "$.X[*].Y[5:8]"
+    * @param {dict} source_message The source message used to get the array lengths
+    *   (by parsing source_jspath)
     * @param {dict} message_for_update The message used for update
     * @param {string} source_jspath Souce JSON path string
     * @param {string} dest_jspath Destination JSON path string

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -45,7 +45,7 @@ class ArrayPathTree:
         self.children = []
 
     def add_child(self, idx, val):
-        child = ArrayPathTree(idx, val, True)
+        child = ArrayPathTree(idx, val)
         self.children.append(child)
         return child
 
@@ -99,7 +99,7 @@ def assign_json_path_values(
     # C[0] C[1] C[2] C[0]   C[1]
     #
     source_jspath_arrays = source_jspath.split('[*]')[:-1]
-    dest_jspath_arrays = [m.strip('.') for m in dest_jspath.split('[*]')][:-1]
+    dest_jspath_arrays = [m.lstrip('$').strip('.') for m in dest_jspath.split('[*]')][:-1]
     if len(source_jspath_arrays) != len(dest_jspath_arrays):
         raise ValueError(
             "inconsistent number of arrays found from the output source and destination path in CMA"

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -46,13 +46,6 @@ class JspathTree:
         return child
 
 
-# function to print all path from root
-# to leaf in binary tree
-def printPaths(root):
-    # list to store path
-    path = []
-    printPathsRec(root, path, 0)
- 
 # Helper function to print path from root
 # to leaf in binary tree
 def printPathsRec(root, path, pathLen):
@@ -128,7 +121,7 @@ def assign_json_path_values(
                 count += 1
         parents = children
 
-    printPaths(root)
+    printPathsRec(root, [], 0)
     import sys; sys.exit(0)
 
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -7,17 +7,17 @@ from copy import deepcopy
 from jsonpath_ng import parse
 
 
-def assign_json_path_value(source_message, jspath, value):
+def assign_json_path_value(message_for_update, jspath, value):
     """
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if jspath doesn't already exist in the message. In this case, we
     * support 'simple' jsonpath like $.path1.path2.path3....
-    * @param {dict} source_message The message to be updated
+    * @param {dict} message_for_update The message to be updated
     * @param {string} jspath JSON path string
     * @param {*} value Value to update to
     * @return {*} updated message
     """
-    message = deepcopy(source_message)
+    message = deepcopy(message_for_update)
     if not parse(jspath).find(message):
         paths = jspath.lstrip('$.').split('.')
         current_item = message
@@ -36,22 +36,22 @@ def assign_json_path_value(source_message, jspath, value):
     return message
 
 
-def assign_json_path_values(source_message, jspath, value):
+def assign_json_path_values(source_message, message_for_update, source_jspath, dest_jspath, value):
     """
     * Assign (update or insert) a value to message based on jsonpath.
-    * Create the keys if jspath doesn't already exist in the message. In this case, we
+    * Create the keys if dest_jspath doesn't already exist in the message. In this case, we
     * support 'simple' jsonpath like $.path1.path2.path3....
-    * @param {dict} source_message The message to be updated
-    * @param {string} jspath JSON path string
+    * @param {dict} message_for_update The message to be updated
+    * @param {string} dest_jspath JSON path string
     * @param {*} value Value to update to
     * @return {*} updated message
     """
-    message = deepcopy(source_message)
-    if jspath[0]=='[':
-        jspath = jspath.lstrip('[').rstrip(']')
+    message = deepcopy(message_for_update)
+    if dest_jspath[0]=='[':
+        dest_jspath = dest_jspath.lstrip('[').rstrip(']')
     flag_array_jspath = False
-    if not parse(jspath).find(message):
-        paths = jspath.lstrip('$.').split('.')
+    if not parse(dest_jspath).find(message):
+        paths = dest_jspath.lstrip('$.').split('.')
         current_item = message
         key_not_found = False
         for path in paths:
@@ -91,10 +91,10 @@ def assign_json_path_values(source_message, jspath, value):
                 else:
                     current_item = current_item[path]
     if flag_array_jspath:
-        #parse(jspath).update(message, value)
-        match_data = parse(jspath).find(message)
+        #parse(dest_jspath).update(message, value)
+        match_data = parse(dest_jspath).find(message)
         for item,v in zip(match_data,value):
             item.full_path.update(message,v)
     else:
-        parse(jspath).update(message, value)
+        parse(dest_jspath).update(message, value)
     return message

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from pprint import pprint
 from jsonpath_ng import parse
+from jsonpath_ng.ext import parse as parse_ext
 
 
 from copy import deepcopy
@@ -12,7 +13,7 @@ def assign_json_path_value(message_for_update, jspath, value):
     * Assign (update or insert) a value to message based on jsonpath.
     * Create the keys if jspath doesn't already exist in the message. In this case, we
     * support 'simple' jsonpath like $.path1.path2.path3....
-    * @param {dict} message_for_update The message to be updated
+    * @param {dict} message_for_update The message used for update
     * @param {string} jspath JSON path string
     * @param {*} value Value to update to
     * @return {*} updated message
@@ -48,6 +49,8 @@ def assign_json_path_values(
     * @param {*} value Value to update to
     * @return {*} updated message
     """
+    # Get the hierarchy of array size from dest_jspath
+
     message = deepcopy(message_for_update)
     if dest_jspath[0] == "[":
         dest_jspath = dest_jspath.lstrip("[").rstrip("]")

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -127,17 +127,15 @@ def assign_json_path_values(
         ]
         if len(nums_children) != len(parents):
             raise Exception("Something goes wrong")
-        children = []
         for parent, num_children in zip(parents, nums_children):
-            for j in range(num_children):
-                child = parent.add_child(dest_jspath_array, j)
-                children.append(child)
+            children = [
+                parent.add_child(dest_jspath_array, i) for i in range(num_children)
+            ]
         parents = children
 
     # Build the tree
     path_list = []
     build_jspath_recursively(root, path_list, [], 0)
-    print(path_list)
 
     # Update the jspath
     count = 0

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -72,23 +72,12 @@ def printPathsRec(root, path_list, path, pathLen):
     if not root.children:
          
         # leaf node then print the list
-        printArray(path, pathLen)
-        print("indside path: ",path)
-        print("indside list before: ",path_list)
         path_list.append(deepcopy(path))
-        print("indside list after : ",path_list)
     else:
         # try for left and right subtree
         for child in root.children:
             printPathsRec(child, path_list, path, pathLen)
  
-# Helper function to print list in which
-# root-to-leaf path is stored
-def printArray(ints, len):
-    for i in ints[0 : len]:
-        print(i," ",end="")
-    print()
-
 def assign_json_path_values(
     source_message, source_jspath, message_for_update, dest_jspath, value
 ):

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from pprint import pprint
 from jsonpath_ng import parse
 from jsonpath_ng.ext import parse as parse_ext
 
@@ -65,8 +64,6 @@ def assign_json_path_values(
                 path = path.split("[")[0]
                 flag_array = True
                 flag_array_jspath = True
-            print(path)
-            pprint(type(current_item))
             if isinstance(current_item, list):
                 current_items = current_item
                 for current_item in current_items:

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -81,8 +81,10 @@ def assign_json_path_values(
 
     # Split source and destination jsonpath by their array components
     #   with root ('$.') skipped
-    # For example, a jsonpath of "$.A.B[*].C[*]" will be split into:
+    # For example, a jsonpath of '$.A.B[0:2].C[*].D' will be split into:
     #   ['A.B', 'C']
+    # and a jsonpath of '$.A[*].B.C[:3].D' will be split into:
+    #   ['A', 'B.C']
     [source_jspath_arrays, dest_jspath_arrays] = list(
         map(
             lambda x: re.findall(r"(.*?)\[[0-9:\*]+\]\.?", x.lstrip("$.")),
@@ -116,9 +118,7 @@ def assign_json_path_values(
     #
     root = ArrayPathTree("$", 0, is_root=True)
     parents = [root]
-    for idx, (source_jspath_array, dest_jspath_array) in enumerate(
-        zip(source_jspath_arrays, dest_jspath_arrays)
-    ):
+    for idx, dest_jspath_array in enumerate(dest_jspath_arrays):
         source_jspath_partial = "$." + "[*].".join(source_jspath_arrays[: idx + 1])
         print(source_jspath_partial)
         nums_children = [

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -124,12 +124,17 @@ def assign_json_path_values(
     build_jspath_recursively(root, path_list, [], 0)
     from pprint import pprint; pprint(path_list)
 
-    #
+    # Update
+    count = 0
+    pprint(message)
     for path in path_list:
-        jspath = '.'.join(path)
+        jspath = '.'.join(path) + dest_jspath.split('[*]')[-1] #NOTE not clean
         print(jspath)
+        parse_ext(jspath).update_or_create(message, value[count])
+        count += 1
+    pprint(message)
 
-    import sys; sys.exit(0)
+    return message
 
 
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -51,6 +51,11 @@ class JsonpathArrayTree:
 
 
 def build_jspath_array_list(root, jsonpath_array_list, path, tree_level):
+    """
+    Traverse the tree and
+      get list of node values (which is the array components of the jsonpath)
+      along each tree path from root to leaf
+    """
 
     if len(path) > tree_level:
         path[tree_level] = root.val

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -36,7 +36,6 @@ def assign_json_path_value(message_for_update, jspath, value):
 class JspathTree:
 
     def __init__(self, idx=0, val="", is_array=False):
-        self.idx = idx
         self.val = val
         if is_array:
             self.val += '['+str(idx)+']'
@@ -48,35 +47,19 @@ class JspathTree:
         return child
 
 
-# Helper function to print path from root
-# to leaf in binary tree
-def printPathsRec(root, path_list, path, pathLen):
-     
-    # Base condition - if binary tree is
-    # empty return
-    if root is None:
-        return
- 
-    # add current root's val into
-    # path_ar list
-     
-    # if length of list is gre
-    if(len(path) > pathLen):
-        path[pathLen] = root.val
+def build_jspath_recursively(root, path_list, path, tree_level):
+
+    if(len(path) > tree_level):
+        path[tree_level] = root.val
     else:
         path.append(root.val)
- 
-    # increment pathLen by 1
-    pathLen = pathLen + 1
- 
-    if not root.children:
-         
-        # leaf node then print the list
-        path_list.append(deepcopy(path))
-    else:
-        # try for left and right subtree
+  
+    if root.children:
+        tree_level = tree_level + 1
         for child in root.children:
-            printPathsRec(child, path_list, path, pathLen)
+            build_jspath_recursively(child, path_list, path, tree_level)
+    else:
+        path_list.append(deepcopy(path))
  
 def assign_json_path_values(
     source_message, source_jspath, message_for_update, dest_jspath, value
@@ -117,7 +100,7 @@ def assign_json_path_values(
         parents = children
 
     path_list = []
-    printPathsRec(root, path_list, [], 0)
+    build_jspath_recursively(root, path_list, [], 0)
     from pprint import pprint; pprint(path_list)
     import sys; sys.exit(0)
 

--- a/message_adapter/util.py
+++ b/message_adapter/util.py
@@ -80,7 +80,7 @@ def assign_json_path_values(
     message = deepcopy(message_for_update)
 
     # Split source and destination jsonpath by their array components
-    #   with root ('$.') skipped
+    #   with root ('$.') skipped.
     # For example, a jsonpath of '$.A.B[0:2].C[*].D' will be split into:
     #   ['A.B', 'C']
     # and a jsonpath of '$.A[*].B.C[:3].D' will be split into:
@@ -96,10 +96,11 @@ def assign_json_path_values(
             "inconsistent number of arrays found from the output source and destination path in CMA"
         )
 
-    # Construct the tree which saves the array part of the jsonpath
-    # The top tree level is the root of jsonpath ("$")
-    #   and the subsequent levels are partitioned by the array components of the jsonpath
-    # The degree of a tree node is determined by the number of elements from source_jsonpath
+    # Construct the tree which saves the array part of the jsonpath.
+    # The top tree level is the root of jsonpath ("$"),
+    #   and the subsequent levels are partitioned by the array components of the jsonpath.
+    # The degree of a tree node is determined by the number of elements from source_jsonpath,
+    #   and the array index is included in the node value.
     # E.g., for a source_jsonpath of "$.X[*].Y[*]" and a dest_jsonpath of "$.A.B[*].C[*]",
     #   if the array size is 2 for "$.X[*]", 3 for "$.X[0].Y[*]", and 2 for "$.X[1].Y[*]",
     #   the tree structure will be:
@@ -120,7 +121,6 @@ def assign_json_path_values(
     parents = [root]
     for idx, dest_jspath_array in enumerate(dest_jspath_arrays):
         source_jspath_partial = "$." + "[*].".join(source_jspath_arrays[: idx + 1])
-        print(source_jspath_partial)
         nums_children = [
             m.value
             for m in parse_ext(source_jspath_partial + ".`len`").find(source_message)
@@ -128,17 +128,16 @@ def assign_json_path_values(
         if len(nums_children) != len(parents):
             raise Exception("Something goes wrong")
         children = []
-        count = 0
-        for i, parent in enumerate(parents):
-            for j in range(nums_children[i]):
+        for parent, num_children in zip(parents, nums_children):
+            for j in range(num_children):
                 child = parent.add_child(dest_jspath_array, j)
                 children.append(child)
-                count += 1
         parents = children
 
     # Build the tree
     path_list = []
     build_jspath_recursively(root, path_list, [], 0)
+    print(path_list)
 
     # Update the jspath
     count = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonpath-ng~=1.4.2
+jsonpath-ng~=1.5.3
 jsonschema==2.6.0
 boto3~=1.18.40
 six~=1.12.0

--- a/tests/test-module.py
+++ b/tests/test-module.py
@@ -451,6 +451,20 @@ class Test(unittest.TestCase):  # pylint: disable=too-many-public-methods
         result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
         assert result == out_msg
 
+    def test_jsonpath_array(self):
+        """ test jsonpath_array.input.json """
+        inp = open(os.path.join(self.test_folder, 'jsonpath_array.input.json'), encoding='utf-8')
+        out = open(os.path.join(self.test_folder, 'jsonpath_array.output.json'), encoding='utf-8')
+        in_msg = json.loads(inp.read())
+        out_msg = json.loads(out.read())
+
+        msg = self.cumulus_message_adapter.load_nested_event(in_msg, {})
+        message_config = msg.get('messageConfig')
+        if 'messageConfig' in msg:
+            del msg['messageConfig']
+        result = self.cumulus_message_adapter.create_next_event(msg, in_msg, message_config)
+        assert result == out_msg
+
     def test_meta(self):
         """ test meta.input.json """
         inp = open(os.path.join(self.test_folder, 'meta.input.json'), encoding='utf-8')


### PR DESCRIPTION
This request implemented CMA feature request #82 (CMA output name changes for an array).

Notes:

1.  Testing has been added and validated with [another pending PR which fixes the broken test in main](https://github.com/nasa/cumulus-message-adapter/pull/81).
2. There are 2 pylint warnings:
```
message_adapter/util.py:36:0: R0903: Too few public methods (1/2) (too-few-public-methods)
message_adapter/util.py:81:0: R0914: Too many local variables (20/15) (too-many-locals)
```
I am a little bit reluctant to adapt my code rewardingly, and not sure we can ignore them or not, but please let me know if it causes issue for CICD.

The current PR should only add the new feature and should not affect any other existing implementation.

It does introduce a tree structure for source->destination array mapping, which is documented in the detail in the source code, but please let me know if it's not straightforward to follow and I will be happy to have a walkthrough.

Thanks!