### PR TITLE
Remove unused dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 jsonpath-ng~=1.4.2
 jsonschema==2.6.0
 boto3~=1.18.40
-six~=1.12.0
-typed-ast>=1.3.0; implementation_name == "cpython"


### PR DESCRIPTION
This is a request in PR form to remove unused dependencies. From what I can tell these dependencies are not referenced anywhere in the code. `six` is also used by `jsonpath-ng` so if there's some reason why version `1.4.2` of needs to have `six` pinned to `1.12.0` then let's add a comment which documents that.

For reference here is the output of `pipenv graph --reverse` for an environment with only this package installed.

<details>
<pre><code>
decorator==5.1.1
  - jsonpath-ng==1.4.3 [requires: decorator]
    - cumulus-message-adapter==2.0.2 [requires: jsonpath-ng~=1.4.2]
      - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
jmespath==0.10.0
  - boto3==1.18.65 [requires: jmespath>=0.7.1,<1.0.0]
    - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
      - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
  - botocore==1.21.65 [requires: jmespath>=0.7.1,<1.0.0]
    - boto3==1.18.65 [requires: botocore>=1.21.65,<1.22.0]
      - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
        - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
    - s3transfer==0.5.2 [requires: botocore>=1.12.36,<2.0a.0]
      - boto3==1.18.65 [requires: s3transfer>=0.5.0,<0.6.0]
        - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
          - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
jsonschema==2.6.0
  - cumulus-message-adapter==2.0.2 [requires: jsonschema==2.6.0]
    - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
pip==23.0
ply==3.11
  - jsonpath-ng==1.4.3 [requires: ply]
    - cumulus-message-adapter==2.0.2 [requires: jsonpath-ng~=1.4.2]
      - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
setuptools==67.1.0
six==1.12.0
  - cumulus-message-adapter==2.0.2 [requires: six~=1.12.0]
    - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
  - jsonpath-ng==1.4.3 [requires: six]
    - cumulus-message-adapter==2.0.2 [requires: jsonpath-ng~=1.4.2]
      - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
  - python-dateutil==2.8.2 [requires: six>=1.5]
    - botocore==1.21.65 [requires: python-dateutil>=2.1,<3.0.0]
      - boto3==1.18.65 [requires: botocore>=1.21.65,<1.22.0]
        - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
          - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
      - s3transfer==0.5.2 [requires: botocore>=1.12.36,<2.0a.0]
        - boto3==1.18.65 [requires: s3transfer>=0.5.0,<0.6.0]
          - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
            - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
typed-ast==1.5.4
  - cumulus-message-adapter==2.0.2 [requires: typed-ast>=1.3.0]
    - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
urllib3==1.26.15
  - botocore==1.21.65 [requires: urllib3>=1.25.4,<1.27]
    - boto3==1.18.65 [requires: botocore>=1.21.65,<1.22.0]
      - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
        - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
    - s3transfer==0.5.2 [requires: botocore>=1.12.36,<2.0a.0]
      - boto3==1.18.65 [requires: s3transfer>=0.5.0,<0.6.0]
        - cumulus-message-adapter==2.0.2 [requires: boto3~=1.18.40]
          - cumulus-message-adapter-python==2.1.0 [requires: cumulus-message-adapter>=2.0.0,<2.1.0]
</code></pre>
</details>