### PR TITLE
[CUMULUS-3277] Update Python version and testing framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,6 @@
 #
 version: 2
 references:
-  container_python36: &container_python36
-    docker:
-      - image: circleci/python:3.6.2
-      - name: localstack
-        image: localstack/localstack:0.11.5
-    working_directory: ~/repo
-
-  restore_cache_python36: &restore_cache_python36
-    restore_cache:
-      keys:
-        - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-        # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
-
-  save_cache_python36: &save_cache_python36
-    save_cache:
-      paths:
-        - ~/venv36
-      key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-
-
   container_python38: &container_python38
     docker:
       - image: circleci/python:3.8.1
@@ -47,30 +26,6 @@ references:
 
 
 jobs:
-  build_python36:
-    <<: *container_python36
-    steps:
-      - checkout
-      - *restore_cache_python36
-      - run:
-          name: install dependencies
-          command: |
-            pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv36
-            . ~/venv36/bin/activate
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-            pip install .
-      - *save_cache_python36
-      - run:
-          name: run tests
-          environment:
-            LOCALSTACK_HOST: localstack
-          command: |
-            . ~/venv36/bin/activate
-            pylint_runner
-            CUMULUS_ENV=testing nosetests -v -s
-
   build_python38:
     <<: *container_python38
     steps:
@@ -95,7 +50,7 @@ jobs:
             CUMULUS_ENV=testing nosetests -v -s
 
   publish_github:
-    <<: *container_python36
+    <<: *container_python38
     steps:
       - checkout
       - add_ssh_keys
@@ -142,15 +97,15 @@ jobs:
             fi
 
   publish_pypi:
-    <<: *container_python36
+    <<: *container_python38
     steps:
       - checkout
-      - *restore_cache_python36
+      - *restore_cache_python38
       - run:
           name: Deploy to PyPi
           command: |
             pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv36
+            ~/.local/bin/virtualenv ~/venv38
             . ~/venv36/bin/activate
             pip install twine
             python setup.py sdist
@@ -160,11 +115,9 @@ workflows:
   version: 2
   build_test_publish:
     jobs:
-      - build_python36
       - build_python38
       - publish_github:
           requires:
-            - build_python36
             - build_python38
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     <<: *container_python310
     steps:
       - checkout
-      - *restore_cache_python310
+      # - *restore_cache_python310
       - run:
           name: install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,53 +4,53 @@
 #
 version: 2
 references:
-  container_python38: &container_python38
+  container_python310: &container_python310
     docker:
-      - image: circleci/python:3.8.1
+      - image: circleci/python:3.10.11
       - name: localstack
-        image: localstack/localstack:0.11.5
+        image: localstack/localstack:2.0.2
     working_directory: ~/repo
 
-  restore_cache_python38: &restore_cache_python38
+  restore_cache_python310: &restore_cache_python310
     restore_cache:
       keys:
         - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         # fallback to using the latest cache if no exact match is found
         - v1-dependencies-
 
-  save_cache_python38: &save_cache_python38
+  save_cache_python310: &save_cache_python310
     save_cache:
       paths:
-        - ~/venv38
+        - ~/venv310
       key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
 
 jobs:
-  build_python38:
-    <<: *container_python38
+  build_python310:
+    <<: *container_python310
     steps:
       - checkout
-      - *restore_cache_python38
+      - *restore_cache_python310
       - run:
           name: install dependencies
           command: |
-            /usr/local/bin/virtualenv ~/venv38
-            . ~/venv38/bin/activate
+            /usr/local/bin/virtualenv ~/venv310
+            . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
             pip install .
-      - *save_cache_python38
+      - *save_cache_python310
       - run:
           name: run tests
           environment:
             LOCALSTACK_HOST: localstack
           command: |
-            . ~/venv38/bin/activate
+            . ~/venv310/bin/activate
             pylint_runner
-            CUMULUS_ENV=testing nosetests -v -s
+            CUMULUS_ENV=testing nose2 -v
 
   publish_github:
-    <<: *container_python38
+    <<: *container_python310
     steps:
       - checkout
       - add_ssh_keys
@@ -77,8 +77,8 @@ jobs:
                   --data $CREATE_RELEASE_REQUEST_BODY | jq .
               echo "Building ${ZIPFILENAME}"
               pip install --user virtualenv
-              ~/.local/bin/virtualenv ~/venv36
-              . ~/venv36/bin/activate
+              ~/.local/bin/virtualenv ~/venv310
+              . ~/venv310/bin/activate
               sudo pip install -r requirements.txt
               make clean
               make $ZIPFILENAME
@@ -97,16 +97,16 @@ jobs:
             fi
 
   publish_pypi:
-    <<: *container_python38
+    <<: *container_python310
     steps:
       - checkout
-      - *restore_cache_python38
+      - *restore_cache_python310
       - run:
           name: Deploy to PyPi
           command: |
             pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv38
-            . ~/venv36/bin/activate
+            ~/.local/bin/virtualenv ~/venv310
+            . ~/venv310/bin/activate
             pip install twine
             python setup.py sdist
             twine upload --skip-existing --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*
@@ -115,10 +115,10 @@ workflows:
   version: 2
   build_test_publish:
     jobs:
-      - build_python38
+      - build_python310
       - publish_github:
           requires:
-            - build_python38
+            - build_python310
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - checkout
       - *restore_cache_python310
       - run:
+          name: Install virtualenv
+          command: pip install --user virtualenv
+      - run:
           name: install dependencies
           command: |
             /usr/local/bin/virtualenv ~/venv310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: install dependencies
           command: |
             pip install --user virtualenv
-            /usr/local/bin/virtualenv ~/venv310
+            ~/.local/bin/virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv310
+            virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,9 @@ jobs:
       - checkout
       - *restore_cache_python310
       - run:
-          name: Install virtualenv
-          command: pip install --user virtualenv
-      - run:
           name: install dependencies
           command: |
+            pip install --user virtualenv
             ~/.local/bin/virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,8 @@ jobs:
           name: install dependencies
           command: |
             pip install --user virtualenv
-            find .
-            ~/.local/bin/virtualenv ~/venv310
-            . ~/venv310/bin/activate
+            ../../venv310
+            . ~/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
             pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,12 @@ jobs:
     <<: *container_python310
     steps:
       - checkout
-      # - *restore_cache_python310
+      - *restore_cache_python310
       - run:
           name: install dependencies
           command: |
             pip install --user virtualenv
+            find .
             ~/.local/bin/virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            /usr/local/bin/virtualenv ~/venv310
+            ~/.local/bin/virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 references:
   container_python310: &container_python310
     docker:
-      - image: circleci/python:3.10.11
+      - image: cimg/python:3.10.11
       - name: localstack
         image: localstack/localstack:2.0.2
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
           name: install dependencies
           command: |
             pip install --user virtualenv
-            ../../venv310
-            . ~/bin/activate
+            ~/.local/bin/virtualenv ~/venv310
+            . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
             pip install .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: install dependencies
           command: |
             pip install --user virtualenv
-            ~/.local/bin/virtualenv ~/venv310
+            /usr/local/bin/virtualenv ~/venv310
             . ~/venv310/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Running tests requires [localstack](https://github.com/localstack/localstack).
 Tests only require localstack running S3, which can be initiated with the following command:
 
 ```shell
-SERVICES=s3 localstack start
+EAGER_SERVICE_LOADING=1 SERVICES=s3 localstack start
 ```
 
 And then you can check tests pass with the following nosetests command:
 
 ```shell
-CUMULUS_ENV=testing nosetests -v -s
+CUMULUS_ENV=testing nose2 -v
 ```
 
 ### Linting

--- a/message_adapter/cumulus_message.py
+++ b/message_adapter/cumulus_message.py
@@ -41,7 +41,7 @@ def load_remote_event(event):
             remote_event = json.loads(data['Body'].read().decode('utf-8'))
             replacement_targets = parsed_json_path.find(event)
             if not replacement_targets or len(replacement_targets) != 1:
-                raise Exception(f'Remote event configuration target {target_json_path} invalid')
+                raise ValueError(f'Remote event configuration target {target_json_path} invalid')
             try:
                 replacement_targets[0].value.update(remote_event)
             except AttributeError:
@@ -161,7 +161,7 @@ def store_remote_response(incoming_event, default_max_size, config_keys):
     cumulus_meta = deepcopy(event['cumulus_meta'])
     replacement_data = replace_config_values['parsed_json_path'].find(event)
     if len(replacement_data) != 1:
-        raise Exception(f'JSON path invalid: {replace_config_values["parsed_json_path"]}')
+        raise ValueError(f'JSON path invalid: {replace_config_values["parsed_json_path"]}')
     replacement_data = replacement_data[0]
 
     estimated_data_size = len(json.dumps(replacement_data.value).encode(('utf-8')))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-nose>=1.3
+nose2>=0.13.0
 mock~=1.3
 pylint>=1.8.2
 flake8~=3.7.9

--- a/tests/test-program.py
+++ b/tests/test-program.py
@@ -13,7 +13,6 @@ from message_adapter import aws
 
 class Test(unittest.TestCase):
     # pylint: disable=attribute-defined-outside-init
-    # pylint: disable=no-self-use
     # pylint: disable=too-many-locals
 
     """ Test class """
@@ -72,7 +71,7 @@ class Test(unittest.TestCase):
                 eoc_count += 1
                 return json.loads(buffer)
         err_string = ''.join([x.decode('utf-8') for x in stream_process.stderr.readlines()])
-        raise Exception(err_string)
+        raise RuntimeError(err_string)
 
     def write_streaming_input(self, command, proc_input, p_stdin):
         """


### PR DESCRIPTION
This PR updates the testing framework `nose` to `nose2` and our CircleCI configuration to build, test, and release from Python 3.10 instead of 3.6 + 3.8.

TODO: Once approved, remove the GitHub checks for Python 3.6 and 3.8