### PR TITLE
Allow more recent minor releases of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonpath-ng~=1.4.2
+jsonpath-ng~=1.4
 jsonschema==4.17.3
-boto3~=1.26.90
+boto3~=1.26


### PR DESCRIPTION
I'm running into an issue where I want to be able to pull in `jsonpath-ng==1.6.1` for the regex filtering capability, however I can't because `cumulus-message-adapter` only allows the `1.4.x` series due to these version constraints. These changes should allow any backwards compatible versions of these dependencies to be pulled in.

From the python specification this is how `~=` constraints work: https://peps.python.org/pep-0440/#compatible-release

> For example, the following groups of version clauses are equivalent:
> ```
> ~= 2.2
> >= 2.2, == 2.*
> 
> ~= 1.4.5
> >= 1.4.5, == 1.4.*
> ```