### PR TITLE
Ecarton/usr prs imp removal patch flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+
+- **CUMULUS-3827**
+  - removed patch specification for jsonpath-ng and boto3 dependencies
+
 ## [v2.0.3] 2023-06-29
 
 ### Updated
 
-- **CUMULUS-3270**
+- **CUMULUS-3827**
+  - removed dependency on imp in setup.py
 
+- **CUMULUS-3270**
   - Upgraded to Python 3.10, updated build jobs. Removed Python 3.8 and 3.6(EOL) build jobs.
   - Updated SDK boto3 version to support new Python runtime versions.
   - Updated pyinstaller and jsonschema versions.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pylint-runner==0.5.4
 flake8~=3.7.9
 autopep8~=1.5.0
 jsonschema==4.17.3
-pyinstaller==5.10.1
+pyinstaller==6.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonpath-ng~=1.4.2
+jsonpath-ng~=1.4
 jsonschema==4.17.3
-boto3~=1.26.90
+boto3~=1.26

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,13 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-# pylint: disable=W0402
-import imp
 
 from os import path
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
+
+# Imports the version number from the version module
+from message_adapter.version import __version__
 
 here = path.abspath(path.dirname(__file__))
 
@@ -23,10 +24,6 @@ print(dependency_links)
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
-
-# Arguments marked as "Required" below must be included for upload to PyPI.
-# Fields marked as "Optional" may be commented out.
-__version__ = imp.load_source('version', 'message_adapter/version.py').__version__
 
 setup(
     name='cumulus-message-adapter',  # Required


### PR DESCRIPTION
rollup of 2 small user prs
one intends to un-block a daac's attempt to use python3.12
the other intends to allow a daac to use different versions of dependencies that they expect are meant to be more flexible